### PR TITLE
Downgrade python dependency to 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ datasets = "^1.5.0"
 coverage = "^5.5"
 annoy = "^1.17.0"
 datasketch = "^1.5.3"
-torch
+torch= ">=1.9.0"
 sentencepiece = "<=0.1.95"
 numpy = "^1.20.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ annoy = "^1.17.0"
 datasketch = "^1.5.3"
 torch = "<=1.9.0"
 sentencepiece = "<=0.1.95"
+numpy = "^1.20.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^20.8b1", allow-prereleases = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ datasets = "^1.5.0"
 coverage = "^5.5"
 annoy = "^1.17.0"
 datasketch = "^1.5.3"
-torch = "<=1.9.0"
+torch # = "<=1.9.0"
 sentencepiece = "<=0.1.95"
 numpy = "^1.20.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ datasets = "^1.5.0"
 coverage = "^5.5"
 annoy = "^1.17.0"
 datasketch = "^1.5.3"
-torch # = "<=1.9.0"
+torch
 sentencepiece = "<=0.1.95"
 numpy = "^1.20.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "text-dedup"
-version = "0.0.11"
+version = "0.0.12"
 description = "Text deduplication with fuzzy match and more"
 authors = ["Chenghao Mou <mouchenghao@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.7.12"
 pandas = "^1.2.3"
 pytest = "^6.2.2"
 alive-progress = "^1.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 pandas = "^1.2.3"
 pytest = "^6.2.2"
 alive-progress = "^1.6.2"

--- a/text_dedup/suffix/__init__.py
+++ b/text_dedup/suffix/__init__.py
@@ -107,7 +107,7 @@ class SuffixArray:
             from multiprocessing import shared_memory
             shared = shared_memory.ShareableList(duplicates)
         except ImportError as e:
-            print(f"The following error was: \n{e}\n\n" + "
+            print(f"The following error was: \n{e}\n\n" + 
                   "This was likely raised since you are not running python 3.8 or higher." + 
                   " Continuing without a shared memory file which is likely be inefficient.")
             shared = duplicates

--- a/text_dedup/suffix/__init__.py
+++ b/text_dedup/suffix/__init__.py
@@ -12,6 +12,7 @@ import multiprocessing as mp
 from numpy.lib.stride_tricks import sliding_window_view
 import numpy as np
 
+
 def similar(x: int, y: int, S: Any, k: int) -> bool:
     """Whether S[x:x+k] is the same as S[y:y+k].
 
@@ -34,7 +35,12 @@ def similar(x: int, y: int, S: Any, k: int) -> bool:
     if x == y:
         return True
 
-    return x + k <= len(S.value) and y + k <= len(S.value) and S.value[x:x+k] == S.value[y:y+k]
+    return (
+        x + k <= len(S.value)
+        and y + k <= len(S.value)
+        and S.value[x : x + k] == S.value[y : y + k]
+    )
+
 
 def group(x: str, patterns: str) -> List[int]:
     """Find patterns that are present in string x.
@@ -57,12 +63,12 @@ def group(x: str, patterns: str) -> List[int]:
             result.append(idx)
     return result
 
-class SuffixArray:
 
+class SuffixArray:
     def __init__(self, k: int = 50):
         self.array = []
         self.k = k
-    
+
     def fit_transform(self, data: List[str]) -> Tuple[List[str], np.ndarray]:
         """Find duplicate substrings in the data.
 
@@ -87,37 +93,43 @@ class SuffixArray:
         suffixes = []
         for i in range(len(S)):
             suffixes.append(S[i:])
-        
+
         self.array = np.argsort(suffixes)
-        
+
         # Find duplicated substrings
         manager = Manager()
         shared = manager.Value(c_char_p, S)
 
         with mp.Pool(mp.cpu_count()) as pool:
-            results = pool.starmap(similar, [(x, y, shared, self.k) for x, y in sliding_window_view(self.array, 2)])
-        
+            results = pool.starmap(
+                similar,
+                [(x, y, shared, self.k) for x, y in sliding_window_view(self.array, 2)],
+            )
+
         duplicates = []
         for idx, dup in zip(self.array, results):
             if dup:
-                duplicates.append(S[idx: idx+self.k])
-        
+                duplicates.append(S[idx : idx + self.k])
+
         # Find duplicated documents
         try:
             from multiprocessing import shared_memory
+
             shared = shared_memory.ShareableList(duplicates)
         except ImportError as e:
-            print(f"The following error was: \n{e}\n\n" + 
-                  "This was likely raised since you are not running python 3.8 or higher." + 
-                  " Continuing without a shared memory file which is likely be inefficient.")
+            print(
+                f"The following error was: \n{e}\n\n"
+                + "This was likely raised since you are not running python 3.8 or higher."
+                + " Continuing without a shared memory file which is likely be inefficient."
+            )
             shared = duplicates
         with mp.Pool(mp.cpu_count()) as pool:
             results = pool.starmap(group, [(d, shared) for d in data])
-        
+
         shared.shm.close()
         shared.shm.unlink()
         del shared
-        
+
         groups = np.zeros((len(data), len(duplicates)), dtype=bool)
         for i, x in enumerate(results):
             for y in x:

--- a/text_dedup/suffix/__init__.py
+++ b/text_dedup/suffix/__init__.py
@@ -9,7 +9,6 @@ from typing import List, Any, Tuple
 from multiprocessing import Manager
 from ctypes import c_char_p
 import multiprocessing as mp
-from multiprocessing import shared_memory
 from numpy.lib.stride_tricks import sliding_window_view
 import numpy as np
 
@@ -104,7 +103,14 @@ class SuffixArray:
                 duplicates.append(S[idx: idx+self.k])
         
         # Find duplicated documents
-        shared = shared_memory.ShareableList(duplicates)
+        try:
+            from multiprocessing import shared_memory
+            shared = shared_memory.ShareableList(duplicates)
+        except ImportError as e:
+            print(f"The following error was: \n{e}\n\n" + "
+                  "This was likely raised since you are not running python 3.8 or higher." + 
+                  " Continuing without a shared memory file which is likely be inefficient.")
+            shared = duplicates
         with mp.Pool(mp.cpu_count()) as pool:
             results = pool.starmap(group, [(d, shared) for d in data])
         


### PR DESCRIPTION
The majority of the features available work well without python 3.8. While the shared memory list is important a lot of the other features could still be used regardless.

I totally understand if you do not wish to integrate these changes but know you at least know that they exist.
