### PR TITLE
Change how hash functions are used in scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: black
         args: [--line-length=120]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v1.4.1
     hooks:
       - id: mypy
         additional_dependencies: [types-all]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: mypy
         additional_dependencies: [types-all]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/poetry.lock
+++ b/poetry.lock
@@ -303,6 +303,40 @@ files = [
 ]
 
 [[package]]
+name = "blake3"
+version = "0.3.3"
+description = "Python bindings for the Rust blake3 crate"
+optional = false
+python-versions = "*"
+files = [
+    {file = "blake3-0.3.3-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:f6443ee7e80cff7936a0b68b8d9c482548a7bd29e463419a59bb3f1e67dcad35"},
+    {file = "blake3-0.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed2b9e4327fbe35897ddcf61b7874dd7d8de102234b86b8d6c4aff442cf3dc57"},
+    {file = "blake3-0.3.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48ea05bbc964edbf1e4e9e5a4d9c2df50fa80a295c16f0cf51321eb6273d3b7d"},
+    {file = "blake3-0.3.3-cp310-none-win32.whl", hash = "sha256:97ccac1fe423d80e400f3172114fe09c430cb74442abd096592b7e4986960c55"},
+    {file = "blake3-0.3.3-cp310-none-win_amd64.whl", hash = "sha256:e1724c115226c471f01d562e82f1f84c9d677b9c4ac13a0ece6c5be4928d4272"},
+    {file = "blake3-0.3.3-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:7d3c62ec8aa4c3c21c72496fd0004862d8f7e1eeb69a574d0a8469d6c7f47ece"},
+    {file = "blake3-0.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e04a8f3046cbb450d6ba6075e085fa624d52af0a8e6abdb03f2601244c8f3fb7"},
+    {file = "blake3-0.3.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ccf773e9fa772d21ef60f643a6a346ea722bdc12d86453359db5f12fe7679022"},
+    {file = "blake3-0.3.3-cp311-none-win32.whl", hash = "sha256:ac8a208102c0418953a747fb794789c2cf2e7c3111db72a51bbd2fe0d236bc0a"},
+    {file = "blake3-0.3.3-cp311-none-win_amd64.whl", hash = "sha256:60b040b2cadc5308fd381fccec288b3a44e0a78d39fffa939da751c5044edb87"},
+    {file = "blake3-0.3.3-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:69269ac2777ea5082e01558ebb9d7d354672414d56de3955c8dada4846192bc4"},
+    {file = "blake3-0.3.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8265bf4846371589f471b52281c54402853e9bb95bfb160bab38ab8839734ac4"},
+    {file = "blake3-0.3.3-cp37-none-win32.whl", hash = "sha256:08f3122ddd4345cbcc83fa1acc8287f2dfb449d77036f73967d56b96dfc919e6"},
+    {file = "blake3-0.3.3-cp37-none-win_amd64.whl", hash = "sha256:89e084b0a5967bcd949a8bb75c4fe40562b59c170fe6aca92acb5de4fc4e97ca"},
+    {file = "blake3-0.3.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:f3363e23a385feb67a845a2b87a1dde6aa952bae5b34189bf9a674fbc2431565"},
+    {file = "blake3-0.3.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a2fb9ba8edc59ad889aa8352b39ae5e254fe1a466a9031635ce38f97df78be6f"},
+    {file = "blake3-0.3.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c13bf3c30f843d2de05d0a4f5f705611307bebdc4b81b33555a220e0131f103"},
+    {file = "blake3-0.3.3-cp38-none-win32.whl", hash = "sha256:6a72458e712c511bdc0eb88de79c992977c79194806e9892f2c1b3f6902d85a2"},
+    {file = "blake3-0.3.3-cp38-none-win_amd64.whl", hash = "sha256:0d9d9d25fca5f65940c780693500e85db57f10b3281153af7a965dbed094546a"},
+    {file = "blake3-0.3.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:6293cc474af332bb3a99d93d2395a92cb7945707749eb52e7729dd85c0097275"},
+    {file = "blake3-0.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e3324a793c4771a77a3640c2a0512b456666c2bc43e0b8c651b8fd488fb56404"},
+    {file = "blake3-0.3.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8299a67e7c81ae28815192bc99b0eaaf02857a73e18209e3c763b16defd35ce9"},
+    {file = "blake3-0.3.3-cp39-none-win32.whl", hash = "sha256:ef8865081fcbbeee3d536a62b4ba2a7b8b41d6479c88d7c6da0cd68a24ca9be2"},
+    {file = "blake3-0.3.3-cp39-none-win_amd64.whl", hash = "sha256:320c3a046d2d931a022900b9272ae4e625d1c5761740dbf4072b65401b73531d"},
+    {file = "blake3-0.3.3.tar.gz", hash = "sha256:0a78908b6299fd21dd46eb00fa4592b259ee419d586d545a3b86e1f2e4d0ee6d"},
+]
+
+[[package]]
 name = "certifi"
 version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2737,4 +2771,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.12"
-content-hash = "32b2626802a0650957d1904f67e2e6c8c169b62f80d2b7ad8cbf6b442351890b"
+content-hash = "0fc4980c74f074a22bf6e5b624ec6124bd355029629db43510448c09bfa3cb9d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -303,40 +303,6 @@ files = [
 ]
 
 [[package]]
-name = "blake3"
-version = "0.3.3"
-description = "Python bindings for the Rust blake3 crate"
-optional = false
-python-versions = "*"
-files = [
-    {file = "blake3-0.3.3-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:f6443ee7e80cff7936a0b68b8d9c482548a7bd29e463419a59bb3f1e67dcad35"},
-    {file = "blake3-0.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed2b9e4327fbe35897ddcf61b7874dd7d8de102234b86b8d6c4aff442cf3dc57"},
-    {file = "blake3-0.3.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48ea05bbc964edbf1e4e9e5a4d9c2df50fa80a295c16f0cf51321eb6273d3b7d"},
-    {file = "blake3-0.3.3-cp310-none-win32.whl", hash = "sha256:97ccac1fe423d80e400f3172114fe09c430cb74442abd096592b7e4986960c55"},
-    {file = "blake3-0.3.3-cp310-none-win_amd64.whl", hash = "sha256:e1724c115226c471f01d562e82f1f84c9d677b9c4ac13a0ece6c5be4928d4272"},
-    {file = "blake3-0.3.3-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:7d3c62ec8aa4c3c21c72496fd0004862d8f7e1eeb69a574d0a8469d6c7f47ece"},
-    {file = "blake3-0.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e04a8f3046cbb450d6ba6075e085fa624d52af0a8e6abdb03f2601244c8f3fb7"},
-    {file = "blake3-0.3.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ccf773e9fa772d21ef60f643a6a346ea722bdc12d86453359db5f12fe7679022"},
-    {file = "blake3-0.3.3-cp311-none-win32.whl", hash = "sha256:ac8a208102c0418953a747fb794789c2cf2e7c3111db72a51bbd2fe0d236bc0a"},
-    {file = "blake3-0.3.3-cp311-none-win_amd64.whl", hash = "sha256:60b040b2cadc5308fd381fccec288b3a44e0a78d39fffa939da751c5044edb87"},
-    {file = "blake3-0.3.3-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:69269ac2777ea5082e01558ebb9d7d354672414d56de3955c8dada4846192bc4"},
-    {file = "blake3-0.3.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8265bf4846371589f471b52281c54402853e9bb95bfb160bab38ab8839734ac4"},
-    {file = "blake3-0.3.3-cp37-none-win32.whl", hash = "sha256:08f3122ddd4345cbcc83fa1acc8287f2dfb449d77036f73967d56b96dfc919e6"},
-    {file = "blake3-0.3.3-cp37-none-win_amd64.whl", hash = "sha256:89e084b0a5967bcd949a8bb75c4fe40562b59c170fe6aca92acb5de4fc4e97ca"},
-    {file = "blake3-0.3.3-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:f3363e23a385feb67a845a2b87a1dde6aa952bae5b34189bf9a674fbc2431565"},
-    {file = "blake3-0.3.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a2fb9ba8edc59ad889aa8352b39ae5e254fe1a466a9031635ce38f97df78be6f"},
-    {file = "blake3-0.3.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c13bf3c30f843d2de05d0a4f5f705611307bebdc4b81b33555a220e0131f103"},
-    {file = "blake3-0.3.3-cp38-none-win32.whl", hash = "sha256:6a72458e712c511bdc0eb88de79c992977c79194806e9892f2c1b3f6902d85a2"},
-    {file = "blake3-0.3.3-cp38-none-win_amd64.whl", hash = "sha256:0d9d9d25fca5f65940c780693500e85db57f10b3281153af7a965dbed094546a"},
-    {file = "blake3-0.3.3-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:6293cc474af332bb3a99d93d2395a92cb7945707749eb52e7729dd85c0097275"},
-    {file = "blake3-0.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e3324a793c4771a77a3640c2a0512b456666c2bc43e0b8c651b8fd488fb56404"},
-    {file = "blake3-0.3.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8299a67e7c81ae28815192bc99b0eaaf02857a73e18209e3c763b16defd35ce9"},
-    {file = "blake3-0.3.3-cp39-none-win32.whl", hash = "sha256:ef8865081fcbbeee3d536a62b4ba2a7b8b41d6479c88d7c6da0cd68a24ca9be2"},
-    {file = "blake3-0.3.3-cp39-none-win_amd64.whl", hash = "sha256:320c3a046d2d931a022900b9272ae4e625d1c5761740dbf4072b65401b73531d"},
-    {file = "blake3-0.3.3.tar.gz", hash = "sha256:0a78908b6299fd21dd46eb00fa4592b259ee419d586d545a3b86e1f2e4d0ee6d"},
-]
-
-[[package]]
 name = "certifi"
 version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2771,4 +2737,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.12"
-content-hash = "0fc4980c74f074a22bf6e5b624ec6124bd355029629db43510448c09bfa3cb9d"
+content-hash = "32b2626802a0650957d1904f67e2e6c8c169b62f80d2b7ad8cbf6b442351890b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -314,6 +314,82 @@ files = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.15.1"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = "*"
+files = [
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "cfgv"
 version = "3.3.1"
 description = "Validate configuration and produce human readable error messages."
@@ -1693,6 +1769,17 @@ docutils = ">=0.8"
 pybtex = ">=0.16"
 
 [[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+files = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
+
+[[package]]
 name = "pygments"
 version = "2.15.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2589,7 +2676,65 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
+[[package]]
+name = "zstandard"
+version = "0.21.0"
+description = "Zstandard bindings for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "zstandard-0.21.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:649a67643257e3b2cff1c0a73130609679a5673bf389564bc6d4b164d822a7ce"},
+    {file = "zstandard-0.21.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:144a4fe4be2e747bf9c646deab212666e39048faa4372abb6a250dab0f347a29"},
+    {file = "zstandard-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b72060402524ab91e075881f6b6b3f37ab715663313030d0ce983da44960a86f"},
+    {file = "zstandard-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8257752b97134477fb4e413529edaa04fc0457361d304c1319573de00ba796b1"},
+    {file = "zstandard-0.21.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c053b7c4cbf71cc26808ed67ae955836232f7638444d709bfc302d3e499364fa"},
+    {file = "zstandard-0.21.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2769730c13638e08b7a983b32cb67775650024632cd0476bf1ba0e6360f5ac7d"},
+    {file = "zstandard-0.21.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7d3bc4de588b987f3934ca79140e226785d7b5e47e31756761e48644a45a6766"},
+    {file = "zstandard-0.21.0-cp310-cp310-win32.whl", hash = "sha256:67829fdb82e7393ca68e543894cd0581a79243cc4ec74a836c305c70a5943f07"},
+    {file = "zstandard-0.21.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6048a287f8d2d6e8bc67f6b42a766c61923641dd4022b7fd3f7439e17ba5a4d"},
+    {file = "zstandard-0.21.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7f2afab2c727b6a3d466faee6974a7dad0d9991241c498e7317e5ccf53dbc766"},
+    {file = "zstandard-0.21.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff0852da2abe86326b20abae912d0367878dd0854b8931897d44cfeb18985472"},
+    {file = "zstandard-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d12fa383e315b62630bd407477d750ec96a0f438447d0e6e496ab67b8b451d39"},
+    {file = "zstandard-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1b9703fe2e6b6811886c44052647df7c37478af1b4a1a9078585806f42e5b15"},
+    {file = "zstandard-0.21.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df28aa5c241f59a7ab524f8ad8bb75d9a23f7ed9d501b0fed6d40ec3064784e8"},
+    {file = "zstandard-0.21.0-cp311-cp311-win32.whl", hash = "sha256:0aad6090ac164a9d237d096c8af241b8dcd015524ac6dbec1330092dba151657"},
+    {file = "zstandard-0.21.0-cp311-cp311-win_amd64.whl", hash = "sha256:48b6233b5c4cacb7afb0ee6b4f91820afbb6c0e3ae0fa10abbc20000acdf4f11"},
+    {file = "zstandard-0.21.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e7d560ce14fd209db6adacce8908244503a009c6c39eee0c10f138996cd66d3e"},
+    {file = "zstandard-0.21.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e6e131a4df2eb6f64961cea6f979cdff22d6e0d5516feb0d09492c8fd36f3bc"},
+    {file = "zstandard-0.21.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1e0c62a67ff425927898cf43da2cf6b852289ebcc2054514ea9bf121bec10a5"},
+    {file = "zstandard-0.21.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1545fb9cb93e043351d0cb2ee73fa0ab32e61298968667bb924aac166278c3fc"},
+    {file = "zstandard-0.21.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe6c821eb6870f81d73bf10e5deed80edcac1e63fbc40610e61f340723fd5f7c"},
+    {file = "zstandard-0.21.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ddb086ea3b915e50f6604be93f4f64f168d3fc3cef3585bb9a375d5834392d4f"},
+    {file = "zstandard-0.21.0-cp37-cp37m-win32.whl", hash = "sha256:57ac078ad7333c9db7a74804684099c4c77f98971c151cee18d17a12649bc25c"},
+    {file = "zstandard-0.21.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1243b01fb7926a5a0417120c57d4c28b25a0200284af0525fddba812d575f605"},
+    {file = "zstandard-0.21.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ea68b1ba4f9678ac3d3e370d96442a6332d431e5050223626bdce748692226ea"},
+    {file = "zstandard-0.21.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8070c1cdb4587a8aa038638acda3bd97c43c59e1e31705f2766d5576b329e97c"},
+    {file = "zstandard-0.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4af612c96599b17e4930fe58bffd6514e6c25509d120f4eae6031b7595912f85"},
+    {file = "zstandard-0.21.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cff891e37b167bc477f35562cda1248acc115dbafbea4f3af54ec70821090965"},
+    {file = "zstandard-0.21.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9fec02ce2b38e8b2e86079ff0b912445495e8ab0b137f9c0505f88ad0d61296"},
+    {file = "zstandard-0.21.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bdbe350691dec3078b187b8304e6a9c4d9db3eb2d50ab5b1d748533e746d099"},
+    {file = "zstandard-0.21.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b69cccd06a4a0a1d9fb3ec9a97600055cf03030ed7048d4bcb88c574f7895773"},
+    {file = "zstandard-0.21.0-cp38-cp38-win32.whl", hash = "sha256:9980489f066a391c5572bc7dc471e903fb134e0b0001ea9b1d3eff85af0a6f1b"},
+    {file = "zstandard-0.21.0-cp38-cp38-win_amd64.whl", hash = "sha256:0e1e94a9d9e35dc04bf90055e914077c80b1e0c15454cc5419e82529d3e70728"},
+    {file = "zstandard-0.21.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d2d61675b2a73edcef5e327e38eb62bdfc89009960f0e3991eae5cc3d54718de"},
+    {file = "zstandard-0.21.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25fbfef672ad798afab12e8fd204d122fca3bc8e2dcb0a2ba73bf0a0ac0f5f07"},
+    {file = "zstandard-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62957069a7c2626ae80023998757e27bd28d933b165c487ab6f83ad3337f773d"},
+    {file = "zstandard-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14e10ed461e4807471075d4b7a2af51f5234c8f1e2a0c1d37d5ca49aaaad49e8"},
+    {file = "zstandard-0.21.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9cff89a036c639a6a9299bf19e16bfb9ac7def9a7634c52c257166db09d950e7"},
+    {file = "zstandard-0.21.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:52b2b5e3e7670bd25835e0e0730a236f2b0df87672d99d3bf4bf87248aa659fb"},
+    {file = "zstandard-0.21.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b1367da0dde8ae5040ef0413fb57b5baeac39d8931c70536d5f013b11d3fc3a5"},
+    {file = "zstandard-0.21.0-cp39-cp39-win32.whl", hash = "sha256:db62cbe7a965e68ad2217a056107cc43d41764c66c895be05cf9c8b19578ce9c"},
+    {file = "zstandard-0.21.0-cp39-cp39-win_amd64.whl", hash = "sha256:a8d200617d5c876221304b0e3fe43307adde291b4a897e7b0617a61611dfff6a"},
+    {file = "zstandard-0.21.0.tar.gz", hash = "sha256:f08e3a10d01a247877e4cb61a82a319ea746c356a3786558bed2481e6c405546"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\""}
+
+[package.extras]
+cffi = ["cffi (>=1.11)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.12"
-content-hash = "e9bacc666bfbd5c0a7185064592961511f5e9a6e84743f0e58cb87e211901ca6"
+content-hash = "32b2626802a0650957d1904f67e2e6c8c169b62f80d2b7ad8cbf6b442351890b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pyspark = "^3.3.1"
 regex = "^2023.5.5"
 urllib3 = "<=2.0"
 sphinxcontrib-bibtex = "^2.5.0"
+zstandard = "^0.21.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ regex = "^2023.5.5"
 urllib3 = "<=2.0"
 sphinxcontrib-bibtex = "^2.5.0"
 zstandard = "^0.21.0"
+blake3 = "^0.3.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ regex = "^2023.5.5"
 urllib3 = "<=2.0"
 sphinxcontrib-bibtex = "^2.5.0"
 zstandard = "^0.21.0"
-blake3 = "^0.3.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/text_dedup/bloom_filter.py
+++ b/text_dedup/bloom_filter.py
@@ -14,7 +14,6 @@ from text_dedup import logger
 from text_dedup.utils import add_bloom_filter_args
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
-from text_dedup.utils.hashfunc import blake3
 from text_dedup.utils.hashfunc import md5
 from text_dedup.utils.hashfunc import sha256
 from text_dedup.utils.hashfunc import xxh3_128

--- a/text_dedup/bloom_filter.py
+++ b/text_dedup/bloom_filter.py
@@ -4,7 +4,7 @@
 # @Author  : Chenghao Mou (mouchenghao@gmail.com)
 import argparse
 import os
-from hashlib import md5, sha256
+
 
 import datasets
 from datasets.load import load_dataset
@@ -16,6 +16,7 @@ from text_dedup.utils import add_bloom_filter_args
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
 from text_dedup.utils.timer import Timer
+from text_dedup.utils.hashfunc import blake3, md5, sha256, xxh3_128
 
 if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser(
@@ -46,8 +47,10 @@ if __name__ == "__main__":  # pragma: no cover
             )
 
         hash_func = {
+            "blake3": blake3,
             "md5": md5,
             "sha256": sha256,
+            "xxh3": xxh3_128,
         }[args.hash_func]
 
         bf = ScalableBloomFilter(

--- a/text_dedup/bloom_filter.py
+++ b/text_dedup/bloom_filter.py
@@ -49,7 +49,6 @@ if __name__ == "__main__":  # pragma: no cover
             )
 
         hash_func = {
-            "blake3": blake3,
             "md5": md5,
             "sha256": sha256,
             "xxh3": xxh3_128,

--- a/text_dedup/bloom_filter.py
+++ b/text_dedup/bloom_filter.py
@@ -5,7 +5,6 @@
 import argparse
 import os
 
-
 import datasets
 from datasets.load import load_dataset
 from pybloom_live import ScalableBloomFilter
@@ -15,8 +14,11 @@ from text_dedup import logger
 from text_dedup.utils import add_bloom_filter_args
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
+from text_dedup.utils.hashfunc import blake3
+from text_dedup.utils.hashfunc import md5
+from text_dedup.utils.hashfunc import sha256
+from text_dedup.utils.hashfunc import xxh3_128
 from text_dedup.utils.timer import Timer
-from text_dedup.utils.hashfunc import blake3, md5, sha256, xxh3_128
 
 if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser(

--- a/text_dedup/bloom_filter.py
+++ b/text_dedup/bloom_filter.py
@@ -6,6 +6,7 @@ import argparse
 import os
 from hashlib import md5, sha256
 
+import datasets
 from datasets.load import load_dataset
 from pybloom_live import ScalableBloomFilter
 from tqdm import tqdm
@@ -17,7 +18,6 @@ from text_dedup.utils import add_meta_args
 from text_dedup.utils.timer import Timer
 
 if __name__ == "__main__":  # pragma: no cover
-
     parser = argparse.ArgumentParser(
         prog="text_dedup.bloomfilter",
         description="Deduplicate text using Bloom Filter",
@@ -33,7 +33,7 @@ if __name__ == "__main__":  # pragma: no cover
 
     with timer("Total"):
         with timer("Loading"):
-            ds: Dataset = load_dataset(
+            ds: datasets.Dataset = load_dataset(
                 path=args.path,
                 name=args.name,
                 data_dir=args.data_dir,
@@ -65,7 +65,10 @@ if __name__ == "__main__":  # pragma: no cover
 
         with timer("Filtering"):
             ds = ds.filter(
-                lambda _, idx: not flags[idx], with_indices=True, num_proc=os.cpu_count(), desc="Filtering..."
+                lambda _, idx: not flags[idx],
+                with_indices=True,
+                num_proc=os.cpu_count(),
+                desc="Filtering...",
             )
 
         with timer("Saving"):

--- a/text_dedup/ccnet.py
+++ b/text_dedup/ccnet.py
@@ -121,7 +121,6 @@ if __name__ == "__main__":  # pragma: no cover
             )
 
         hash_func = {
-            "blake3": xxh3_128,  # blake3 causes pickling error
             "md5": md5,
             "sha256": sha256,
             "xxh3": xxh3_128,

--- a/text_dedup/ccnet.py
+++ b/text_dedup/ccnet.py
@@ -151,12 +151,12 @@ if __name__ == "__main__":  # pragma: no cover
                 range(0, len(hashed), args.batch_size), desc="Processing..."
             ):
                 batch = hashed[idx : idx + args.batch_size]
-                for h, id, idx in tqdm(
+                for h, id_, idx in tqdm(
                     zip(batch["__hash__"], batch["__id__"], batch["__idx__"]),
                     leave=False,
                 ):
                     if h in hashes:
-                        remove.add((id, idx))
+                        remove.add((id_, idx))
                         continue
                     hashes.add(h)
 

--- a/text_dedup/ccnet.py
+++ b/text_dedup/ccnet.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":  # pragma: no cover
         match args.hash_func:
             case "md5":
                 hash_func = md5
-            case other:
+            case _:
                 hash_func = sha256
 
         hashes = set()

--- a/text_dedup/ccnet.py
+++ b/text_dedup/ccnet.py
@@ -19,7 +19,7 @@ from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
 from text_dedup.utils.timer import Timer
 from text_dedup.utils.preprocess import normalize as normalize_for_dedup
-from text_dedup.utils.hashfunc import blake3, md5, sha256, xxh3_128
+from text_dedup.utils.hashfunc import md5, sha256, xxh3_128
 
 HASH_SIZE = np.uint64(0).nbytes  # 8 bytes
 
@@ -119,7 +119,7 @@ if __name__ == "__main__":  # pragma: no cover
             )
 
         hash_func = {
-            "blake3": blake3,
+            "blake3": xxh3_128,  # blake3 causes pickling error
             "md5": md5,
             "sha256": sha256,
             "xxh3": xxh3_128,

--- a/text_dedup/exact_hash.py
+++ b/text_dedup/exact_hash.py
@@ -12,8 +12,11 @@ from text_dedup import logger
 from text_dedup.utils import add_exact_hash_args
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
+from text_dedup.utils.hashfunc import blake3
+from text_dedup.utils.hashfunc import md5
+from text_dedup.utils.hashfunc import sha256
+from text_dedup.utils.hashfunc import xxh3_128
 from text_dedup.utils.timer import Timer
-from text_dedup.utils.hashfunc import blake3, md5, sha256, xxh3_128
 
 if __name__ == "__main__":  # pragma: no cover
     parser = argparse.ArgumentParser(

--- a/text_dedup/exact_hash.py
+++ b/text_dedup/exact_hash.py
@@ -12,7 +12,6 @@ from text_dedup import logger
 from text_dedup.utils import add_exact_hash_args
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
-from text_dedup.utils.hashfunc import blake3
 from text_dedup.utils.hashfunc import md5
 from text_dedup.utils.hashfunc import sha256
 from text_dedup.utils.hashfunc import xxh3_128
@@ -45,7 +44,6 @@ if __name__ == "__main__":  # pragma: no cover
             )
 
         hash_func = {
-            "blake3": blake3,
             "md5": md5,
             "sha256": sha256,
             "xxh3": xxh3_128,

--- a/text_dedup/exact_hash.py
+++ b/text_dedup/exact_hash.py
@@ -4,7 +4,6 @@
 # @Author  : Chenghao Mou (mouchenghao@gmail.com)
 import argparse
 import os
-from hashlib import md5
 
 from datasets import load_dataset
 from tqdm import tqdm
@@ -14,9 +13,9 @@ from text_dedup.utils import add_exact_hash_args
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
 from text_dedup.utils.timer import Timer
+from text_dedup.utils.hashfunc import blake3, md5, sha256, xxh3_128
 
 if __name__ == "__main__":  # pragma: no cover
-
     parser = argparse.ArgumentParser(
         prog="text_dedup.exacthash",
         description="Deduplicate text using exact hashing",
@@ -43,8 +42,12 @@ if __name__ == "__main__":  # pragma: no cover
             )
 
         hash_func = {
+            "blake3": blake3,
             "md5": md5,
+            "sha256": sha256,
+            "xxh3": xxh3_128,
         }[args.hash_func]
+
         hashes = set()
         flags = []
 
@@ -60,7 +63,11 @@ if __name__ == "__main__":  # pragma: no cover
                         hashes.add(h)
 
         with timer("Filtering"):
-            ds = ds.filter(lambda _, idx: not flags[idx], with_indices=True, num_proc=os.cpu_count())
+            ds = ds.filter(
+                lambda _, idx: not flags[idx],
+                with_indices=True,
+                num_proc=os.cpu_count(),
+            )
 
         with timer("Saving"):
             ds.save_to_disk(args.output)

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -13,6 +13,7 @@ import random
 import re
 from collections import defaultdict
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Set
@@ -52,7 +53,7 @@ def embed_func(
     min_length: int,
     hashranges: List[Tuple[int, int]],
     permutations: np.ndarray,
-    hash_func: callable,
+    hash_func: Callable,
 ) -> Dict[str, Any]:
     """
     Calculate hash values for the content.

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -31,8 +31,9 @@ from text_dedup.utils import ngrams
 from text_dedup.utils.add_args import add_io_args
 from text_dedup.utils.add_args import add_meta_args
 from text_dedup.utils.add_args import add_minhash_args
+from text_dedup.utils.hashfunc import sha1_hash
+from text_dedup.utils.hashfunc import xxh3_hash
 from text_dedup.utils.timer import Timer
-from text_dedup.utils.hashfunc import sha1_hash, xxh3_hash
 
 SEED = 42
 RNG = np.random.RandomState(SEED)
@@ -103,12 +104,8 @@ def embed_func(
     """
     a, b = permutations
     masks: np.ndarray = np.full(shape=num_perm, dtype=np.uint64, fill_value=MAX_HASH)
-    tokens: Set[str] = {
-        " ".join(t) for t in ngrams(NON_ALPHA.split(content), ngram_size, min_length)
-    }
-    hashvalues: np.ndarray = np.array(
-        [hash_func(token.lower().encode("utf-8")) for token in tokens], dtype=np.uint64
-    )
+    tokens: Set[str] = {" ".join(t) for t in ngrams(NON_ALPHA.split(content), ngram_size, min_length)}
+    hashvalues: np.ndarray = np.array([hash_func(token.lower().encode("utf-8")) for token in tokens], dtype=np.uint64)
     permuted_hashvalues = np.bitwise_and(
         ((hashvalues * np.tile(a, (len(hashvalues), 1)).T).T + b) % MERSENNE_PRIME,
         MAX_HASH,

--- a/text_dedup/minhash_spark.py
+++ b/text_dedup/minhash_spark.py
@@ -273,7 +273,6 @@ def generate_edges(nodes: List[int]) -> List[Tuple[int, int]]:
 
 
 if __name__ == "__main__":  # pragma: no cover
-
     import argparse
 
     parser = argparse.ArgumentParser(description="Near-deduplicating BigQuery Table with PySpark")

--- a/text_dedup/simhash.py
+++ b/text_dedup/simhash.py
@@ -34,7 +34,7 @@ from text_dedup.utils import add_meta_args
 from text_dedup.utils import add_simhash_args
 from text_dedup.utils import ngrams
 from text_dedup.utils.timer import Timer
-from text_dedup.utils.hashfunc import xxh64_digest, xxh128_digest
+from text_dedup.utils.hashfunc import xxh3_64_digest, xxh3_128_digest
 
 datasets.logging.set_verbosity_error()
 
@@ -250,9 +250,9 @@ def _unsigned_hash(obj: bytes, f: int = 64) -> bitarray:
     result = bitarray(0)
     match f:
         case 64:
-            result.frombytes(xxh64_digest(obj))
+            result.frombytes(xxh3_64_digest(obj))
         case 128:
-            result.frombytes(xxh128_digest(obj))
+            result.frombytes(xxh3_128_digest(obj))
         case _:
             raise ValueError(f"Unsupported fingerprint size: {f}")
     return result

--- a/text_dedup/simhash.py
+++ b/text_dedup/simhash.py
@@ -32,8 +32,8 @@ from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
 from text_dedup.utils import add_simhash_args
 from text_dedup.utils import ngrams
-from text_dedup.utils.hashfunc import xxh3_64_digest
-from text_dedup.utils.hashfunc import xxh3_128_digest
+from text_dedup.utils.hashfunc import xxh3_64
+from text_dedup.utils.hashfunc import xxh3_128
 from text_dedup.utils.timer import Timer
 
 datasets.logging.set_verbosity_error()
@@ -246,9 +246,9 @@ def _unsigned_hash(obj: bytes, f: int = 64) -> bitarray:
     result = bitarray(0)
     match f:
         case 64:
-            result.frombytes(xxh3_64_digest(obj))
+            result.frombytes(xxh3_64(obj).digest())
         case 128:
-            result.frombytes(xxh3_128_digest(obj))
+            result.frombytes(xxh3_128(obj).digest())
         case _:
             raise ValueError(f"Unsupported fingerprint size: {f}")
     return result
@@ -290,7 +290,7 @@ def embed_func(
     *,
     f: int,
     ngram: int,
-    permutations: List[Permutation] = None,
+    permutations: List[Permutation],
 ) -> Dict[str, Any]:
     """
     Calculate the simhash signature of a text.

--- a/text_dedup/simhash.py
+++ b/text_dedup/simhash.py
@@ -20,7 +20,6 @@ from typing import Tuple
 
 import datasets
 import numpy as np
-
 from bitarray import bitarray
 from bitarray import frozenbitarray
 from datasets import load_dataset
@@ -33,8 +32,9 @@ from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
 from text_dedup.utils import add_simhash_args
 from text_dedup.utils import ngrams
+from text_dedup.utils.hashfunc import xxh3_64_digest
+from text_dedup.utils.hashfunc import xxh3_128_digest
 from text_dedup.utils.timer import Timer
-from text_dedup.utils.hashfunc import xxh3_64_digest, xxh3_128_digest
 
 datasets.logging.set_verbosity_error()
 
@@ -66,9 +66,7 @@ def _hamming_distance(a: bitarray, b: bitarray) -> int:
 
 
 class Permutation:
-    def __init__(
-        self, f: int, k: int, b: int, masks: List[Tuple[bitarray, int, int, int]]
-    ) -> None:
+    def __init__(self, f: int, k: int, b: int, masks: List[Tuple[bitarray, int, int, int]]) -> None:
         """
         A permutation object for bit manipulation.
 
@@ -106,9 +104,7 @@ class Permutation:
 
             self.masks.append(mask)
 
-        assert (
-            sum(self.widths) == f
-        ), "The sum of block widths must be equal to the fingerprint size"
+        assert sum(self.widths) == f, "The sum of block widths must be equal to the fingerprint size"
 
         prefix_width = sum(self.widths[: b - k])
         self.search_mask: bitarray = bitarray(f)
@@ -408,10 +404,7 @@ if __name__ == "__main__":
                         for idy, other_fingerprint in BUCKETS[key]:
                             if idy in neighbors:
                                 continue
-                            if (
-                                _hamming_distance(sig, other_fingerprint)
-                                <= args.bit_diff
-                            ):
+                            if _hamming_distance(sig, other_fingerprint) <= args.bit_diff:
                                 neighbors.add(idy)
                         BUCKETS[key].append((idx, sig))
 

--- a/text_dedup/suffix_array.py
+++ b/text_dedup/suffix_array.py
@@ -277,7 +277,6 @@ def clean_up(text: str, slices: List[slice]) -> str:
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(
         prog="text-dedup.suffixarray",
         description="Deduplicate text using Suffix Array Deduplication",

--- a/text_dedup/utils/__init__.py
+++ b/text_dedup/utils/__init__.py
@@ -10,10 +10,11 @@ from text_dedup.utils.add_args import add_meta_args
 from text_dedup.utils.add_args import add_minhash_args
 from text_dedup.utils.add_args import add_sa_args
 from text_dedup.utils.add_args import add_simhash_args
+from text_dedup.utils.hashfunc import sha1_hash
+from text_dedup.utils.hashfunc import xxh3_hash
 from text_dedup.utils.timer import Timer
 from text_dedup.utils.tokenization import ngrams
 from text_dedup.utils.union_find import UnionFind
-from text_dedup.utils.hashfunc import sha1_hash, xxh3_hash
 
 __all__ = [
     "add_bloom_filter_args",

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -5,9 +5,7 @@
 import argparse
 
 
-def add_io_args(
-    parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:  # pragma: no cover
+def add_io_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add input/output arguments to parser.
 
@@ -28,26 +26,18 @@ def add_io_args(
     parser.add_argument("--split", type=str, help="`split` in load_dataset"),
     parser.add_argument("--cache_dir", type=str, help="`cache_dir` in load_dataset", default=".cache"),
     parser.add_argument("--revision", type=str, help="`revision` in load_dataset"),
-    parser.add_argument("--use_auth_token", type=str, help="`use_auth_token` in load_dataset"),
     parser.add_argument(
-        "--local",
-        action=argparse.BooleanOptionalAction,
-        help="Use local dataset",
-        default=False,
+        "--use_auth_token", action=argparse.BooleanOptionalAction, help="`use_auth_token` in load_dataset"
     ),
+    parser.add_argument("--local", action=argparse.BooleanOptionalAction, help="Use local dataset", default=False),
     parser.add_argument("--output", type=str, help="Path to deduplicated dataset output", required=True),
     parser.add_argument(
-        "--debug",
-        action=argparse.BooleanOptionalAction,
-        help="Whether to run in debug mode",
-        default=False,
+        "--debug", action=argparse.BooleanOptionalAction, help="Whether to run in debug mode", default=False
     )
     return parser
 
 
-def add_meta_args(
-    parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:  # pragma: no cover
+def add_meta_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add meta arguments to parser.
 
@@ -76,9 +66,7 @@ def add_meta_args(
     return parser
 
 
-def add_minhash_args(
-    parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:  # pragma: no cover
+def add_minhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add MinHash arguments to parser.
 
@@ -105,17 +93,9 @@ def add_minhash_args(
         help="Minimum number of tokens to use in MinHash. Shorter documents will be filtered out.",
     )
     parser.add_argument("--seed", type=int, default=42, help="Seed to use in MinHash")
+    parser.add_argument("--num_perm", type=int, default=256, help="Number of permutations to use in MinHash")
     parser.add_argument(
-        "--num_perm",
-        type=int,
-        default=256,
-        help="Number of permutations to use in MinHash",
-    )
-    parser.add_argument(
-        "--threshold",
-        type=float,
-        default=0.7,
-        help="Jaccard similarity threshold to use in MinHashLSH",
+        "--threshold", type=float, default=0.7, help="Jaccard similarity threshold to use in MinHashLSH"
     )
     parser.add_argument(
         "--b",
@@ -140,9 +120,7 @@ def add_minhash_args(
     return parser
 
 
-def add_simhash_args(
-    parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:  # pragma: no cover
+def add_simhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add SimHash arguments to parser.
 
@@ -165,17 +143,12 @@ def add_simhash_args(
     parser.add_argument("--f", type=int, default=64, help="Simhash bit size"),
     parser.add_argument("--bit_diff", type=int, default=3, help="Bit difference to use in SimHash"),
     parser.add_argument(
-        "--num_bucket",
-        type=int,
-        default=4,
-        help="Number of buckets to use in SimHash, must be larger than bit_diff",
+        "--num_bucket", type=int, default=4, help="Number of buckets to use in SimHash, must be larger than bit_diff"
     ),
     return parser
 
 
-def add_sa_args(
-    parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:  # pragma: no cover
+def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add Suffix Array arguments to parser. This adds the following arguments:
 
@@ -196,10 +169,7 @@ def add_sa_args(
         Parser with added arguments.
     """
     parser.add_argument(
-        "--k",
-        type=int,
-        default=100,
-        help="Minimum byte length of a duplicate substring in Suffix Array Deduplication",
+        "--k", type=int, default=100, help="Minimum byte length of a duplicate substring in Suffix Array Deduplication"
     ),
     parser.add_argument(
         "--strategy",
@@ -209,17 +179,12 @@ def add_sa_args(
         choices=["overlapping", "longest"],
     )
     parser.add_argument(
-        "--google_repo_path",
-        type=str,
-        help="Path to google-research-deduplication codebase",
-        required=True,
+        "--google_repo_path", type=str, help="Path to google-research-deduplication codebase", required=True
     ),
     return parser
 
 
-def add_bloom_filter_args(
-    parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:  # pragma: no cover
+def add_bloom_filter_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add Bloom Filter arguments to parser.
 
@@ -233,31 +198,13 @@ def add_bloom_filter_args(
     parser : argparse.ArgumentParser
         Parser with added arguments.
     """
-    parser.add_argument(
-        "--error_rate",
-        type=float,
-        default=1e-6,
-        help="Error rate to use in BloomFilter",
-    ),
-    parser.add_argument(
-        "--hash_func",
-        type=str,
-        choices=["md5", "sha256", "blake3", "xxh3"],
-        default="md5",
-        help="Hash function to use in BloomFilter. defaults to md5",
-    ),
-    parser.add_argument(
-        "--initial_capacity",
-        type=int,
-        default=100,
-        help="Initial capacity of BloomFilter",
-    ),
+    parser.add_argument("--error_rate", type=float, default=1e-6, help="Error rate to use in BloomFilter"),
+    parser.add_argument("--hash_func", type=str, default="md5", help="Hash function to use in BloomFilter"),
+    parser.add_argument("--initial_capacity", type=int, default=100, help="Initial capacity of BloomFilter"),
     return parser
 
 
-def add_exact_hash_args(
-    parser: argparse.ArgumentParser,
-) -> argparse.ArgumentParser:  # pragma: no cover
+def add_exact_hash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add Exact Hash arguments to parser.
 

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -137,6 +137,13 @@ def add_minhash_args(
         default=None,
         help="Number of rows per band",
     )
+    parser.add_argument(
+        "--hash_func",
+        type=str,
+        choices=["sha1", "xxh3"],
+        default="sha1",
+        help="Hashing algorithm. Defaults to sha1. xxh3 is faster",
+    )
 
     return parser
 

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -284,7 +284,7 @@ def add_exact_hash_args(
     parser.add_argument(
         "--hash_func",
         type=str,
-        choices=["md5", "sha256", "xxh3"],
+        choices=["md5", "sha256", "blake3", "xxh3"],
         default="md5",
         help="Hash function to use in ExactHash. defaults to md5",
     ),

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -199,7 +199,13 @@ def add_bloom_filter_args(parser: argparse.ArgumentParser) -> argparse.ArgumentP
         Parser with added arguments.
     """
     parser.add_argument("--error_rate", type=float, default=1e-6, help="Error rate to use in BloomFilter"),
-    parser.add_argument("--hash_func", type=str, default="md5", help="Hash function to use in BloomFilter"),
+    parser.add_argument(
+        "--hash_func",
+        type=str,
+        choices=["md5", "sha256", "xxh3"],
+        default="md5",
+        help="Hash function to use in BloomFilter",
+    ),
     parser.add_argument("--initial_capacity", type=int, default=100, help="Initial capacity of BloomFilter"),
     return parser
 

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -284,7 +284,7 @@ def add_exact_hash_args(
     parser.add_argument(
         "--hash_func",
         type=str,
-        choices=["md5", "sha256", "blake3", "xxh3"],
+        choices=["md5", "sha256", "xxh3"],
         default="md5",
         help="Hash function to use in ExactHash. defaults to md5",
     ),

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -282,6 +282,10 @@ def add_exact_hash_args(
         Parser with added arguments.
     """
     parser.add_argument(
-        "--hash_func", type=str, default="md5", help="Hash function to use in ExactHash"
+        "--hash_func",
+        type=str,
+        choices=["md5", "sha256", "blake3", "xxh3"],
+        default="md5",
+        help="Hash function to use in ExactHash. defaults to md5",
     ),
     return parser

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -221,7 +221,7 @@ def add_exact_hash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
     parser.add_argument(
         "--hash_func",
         type=str,
-        choices=["md5", "sha256", "blake3", "xxh3"],
+        choices=["md5", "sha256", "xxh3"],
         default="md5",
         help="Hash function to use in ExactHash. defaults to md5",
     ),

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -5,7 +5,9 @@
 import argparse
 
 
-def add_io_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
+def add_io_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add input/output arguments to parser.
 
@@ -19,25 +21,41 @@ def add_io_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
     parser : argparse.ArgumentParser
         Parser with added arguments.
     """
-    parser.add_argument("--path", type=str, help="`path` in load_dataset", required=True),
+    parser.add_argument(
+        "--path", type=str, help="`path` in load_dataset", required=True
+    ),
     parser.add_argument("--name", type=str, help="`name` in load_dataset"),
     parser.add_argument("--data_dir", type=str, help="`data_dir` in load_dataset"),
     parser.add_argument("--data_files", type=str, help="`data_files` in load_dataset"),
     parser.add_argument("--split", type=str, help="`split` in load_dataset"),
-    parser.add_argument("--cache_dir", type=str, help="`cache_dir` in load_dataset", default=".cache"),
+    parser.add_argument(
+        "--cache_dir", type=str, help="`cache_dir` in load_dataset", default=".cache"
+    ),
     parser.add_argument("--revision", type=str, help="`revision` in load_dataset"),
     parser.add_argument(
-        "--use_auth_token", action=argparse.BooleanOptionalAction, help="`use_auth_token` in load_dataset"
+        "--use_auth_token", type=str, help="`use_auth_token` in load_dataset"
     ),
-    parser.add_argument("--local", action=argparse.BooleanOptionalAction, help="Use local dataset", default=False),
-    parser.add_argument("--output", type=str, help="Path to deduplicated dataset output", required=True),
     parser.add_argument(
-        "--debug", action=argparse.BooleanOptionalAction, help="Whether to run in debug mode", default=False
+        "--local",
+        action=argparse.BooleanOptionalAction,
+        help="Use local dataset",
+        default=False,
+    ),
+    parser.add_argument(
+        "--output", type=str, help="Path to deduplicated dataset output", required=True
+    ),
+    parser.add_argument(
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        help="Whether to run in debug mode",
+        default=False,
     )
     return parser
 
 
-def add_meta_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
+def add_meta_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add meta arguments to parser.
 
@@ -66,7 +84,9 @@ def add_meta_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  
     return parser
 
 
-def add_minhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
+def add_minhash_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add MinHash arguments to parser.
 
@@ -93,9 +113,17 @@ def add_minhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         help="Minimum number of tokens to use in MinHash. Shorter documents will be filtered out.",
     )
     parser.add_argument("--seed", type=int, default=42, help="Seed to use in MinHash")
-    parser.add_argument("--num_perm", type=int, default=256, help="Number of permutations to use in MinHash")
     parser.add_argument(
-        "--threshold", type=float, default=0.7, help="Jaccard similarity threshold to use in MinHashLSH"
+        "--num_perm",
+        type=int,
+        default=256,
+        help="Number of permutations to use in MinHash",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.7,
+        help="Jaccard similarity threshold to use in MinHashLSH",
     )
     parser.add_argument(
         "--b",
@@ -113,7 +141,9 @@ def add_minhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
     return parser
 
 
-def add_simhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
+def add_simhash_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add SimHash arguments to parser.
 
@@ -134,14 +164,21 @@ def add_simhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         help="""Ngram size to use in SimHash.""",
     )
     parser.add_argument("--f", type=int, default=64, help="Simhash bit size"),
-    parser.add_argument("--bit_diff", type=int, default=3, help="Bit difference to use in SimHash"),
     parser.add_argument(
-        "--num_bucket", type=int, default=4, help="Number of buckets to use in SimHash, must be larger than bit_diff"
+        "--bit_diff", type=int, default=3, help="Bit difference to use in SimHash"
+    ),
+    parser.add_argument(
+        "--num_bucket",
+        type=int,
+        default=4,
+        help="Number of buckets to use in SimHash, must be larger than bit_diff",
     ),
     return parser
 
 
-def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
+def add_sa_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add Suffix Array arguments to parser. This adds the following arguments:
 
@@ -162,7 +199,10 @@ def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
         Parser with added arguments.
     """
     parser.add_argument(
-        "--k", type=int, default=100, help="Minimum byte length of a duplicate substring in Suffix Array Deduplication"
+        "--k",
+        type=int,
+        default=100,
+        help="Minimum byte length of a duplicate substring in Suffix Array Deduplication",
     ),
     parser.add_argument(
         "--strategy",
@@ -172,12 +212,17 @@ def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
         choices=["overlapping", "longest"],
     )
     parser.add_argument(
-        "--google_repo_path", type=str, help="Path to google-research-deduplication codebase", required=True
+        "--google_repo_path",
+        type=str,
+        help="Path to google-research-deduplication codebase",
+        required=True,
     ),
     return parser
 
 
-def add_bloom_filter_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
+def add_bloom_filter_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add Bloom Filter arguments to parser.
 
@@ -191,13 +236,30 @@ def add_bloom_filter_args(parser: argparse.ArgumentParser) -> argparse.ArgumentP
     parser : argparse.ArgumentParser
         Parser with added arguments.
     """
-    parser.add_argument("--error_rate", type=float, default=1e-6, help="Error rate to use in BloomFilter"),
-    parser.add_argument("--hash_func", type=str, default="md5", help="Hash function to use in BloomFilter"),
-    parser.add_argument("--initial_capacity", type=int, default=100, help="Initial capacity of BloomFilter"),
+    parser.add_argument(
+        "--error_rate",
+        type=float,
+        default=1e-6,
+        help="Error rate to use in BloomFilter",
+    ),
+    parser.add_argument(
+        "--hash_func",
+        type=str,
+        default="md5",
+        help="Hash function to use in BloomFilter",
+    ),
+    parser.add_argument(
+        "--initial_capacity",
+        type=int,
+        default=100,
+        help="Initial capacity of BloomFilter",
+    ),
     return parser
 
 
-def add_exact_hash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
+def add_exact_hash_args(
+    parser: argparse.ArgumentParser,
+) -> argparse.ArgumentParser:  # pragma: no cover
     """
     Add Exact Hash arguments to parser.
 
@@ -211,5 +273,7 @@ def add_exact_hash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPar
     parser : argparse.ArgumentParser
         Parser with added arguments.
     """
-    parser.add_argument("--hash_func", type=str, default="md5", help="Hash function to use in ExactHash"),
+    parser.add_argument(
+        "--hash_func", type=str, default="md5", help="Hash function to use in ExactHash"
+    ),
     return parser

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -252,8 +252,9 @@ def add_bloom_filter_args(
     parser.add_argument(
         "--hash_func",
         type=str,
+        choices=["md5", "sha256", "blake3", "xxh3"],
         default="md5",
-        help="Hash function to use in BloomFilter",
+        help="Hash function to use in BloomFilter. defaults to md5",
     ),
     parser.add_argument(
         "--initial_capacity",

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -21,29 +21,21 @@ def add_io_args(
     parser : argparse.ArgumentParser
         Parser with added arguments.
     """
-    parser.add_argument(
-        "--path", type=str, help="`path` in load_dataset", required=True
-    ),
+    parser.add_argument("--path", type=str, help="`path` in load_dataset", required=True),
     parser.add_argument("--name", type=str, help="`name` in load_dataset"),
     parser.add_argument("--data_dir", type=str, help="`data_dir` in load_dataset"),
     parser.add_argument("--data_files", type=str, help="`data_files` in load_dataset"),
     parser.add_argument("--split", type=str, help="`split` in load_dataset"),
-    parser.add_argument(
-        "--cache_dir", type=str, help="`cache_dir` in load_dataset", default=".cache"
-    ),
+    parser.add_argument("--cache_dir", type=str, help="`cache_dir` in load_dataset", default=".cache"),
     parser.add_argument("--revision", type=str, help="`revision` in load_dataset"),
-    parser.add_argument(
-        "--use_auth_token", type=str, help="`use_auth_token` in load_dataset"
-    ),
+    parser.add_argument("--use_auth_token", type=str, help="`use_auth_token` in load_dataset"),
     parser.add_argument(
         "--local",
         action=argparse.BooleanOptionalAction,
         help="Use local dataset",
         default=False,
     ),
-    parser.add_argument(
-        "--output", type=str, help="Path to deduplicated dataset output", required=True
-    ),
+    parser.add_argument("--output", type=str, help="Path to deduplicated dataset output", required=True),
     parser.add_argument(
         "--debug",
         action=argparse.BooleanOptionalAction,
@@ -171,9 +163,7 @@ def add_simhash_args(
         help="""Ngram size to use in SimHash.""",
     )
     parser.add_argument("--f", type=int, default=64, help="Simhash bit size"),
-    parser.add_argument(
-        "--bit_diff", type=int, default=3, help="Bit difference to use in SimHash"
-    ),
+    parser.add_argument("--bit_diff", type=int, default=3, help="Bit difference to use in SimHash"),
     parser.add_argument(
         "--num_bucket",
         type=int,

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -1,11 +1,14 @@
 import hashlib
 import struct
+from hashlib import md5
+from hashlib import sha256
+
 import xxhash
-
-from hashlib import md5, sha256
 from blake3 import blake3
-
-from xxhash import xxh3_64, xxh3_128, xxh3_64_digest, xxh3_128_digest
+from xxhash import xxh3_64
+from xxhash import xxh3_64_digest
+from xxhash import xxh3_128
+from xxhash import xxh3_128_digest
 
 
 def sha1_hash(data: bytes, d: int = 32) -> int:

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -5,7 +5,7 @@ import xxhash
 from hashlib import md5, sha256
 from blake3 import blake3
 
-from xxhash import xxh3_128, xxh3_64_digest, xxh3_128_digest
+from xxhash import xxh3_64, xxh3_128, xxh3_64_digest, xxh3_128_digest
 
 
 def sha1_hash(data: bytes, d: int = 32) -> int:

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -4,6 +4,8 @@ from hashlib import md5
 from hashlib import sha256
 
 import xxhash
+from xxhash import xxh3_64
+from xxhash import xxh3_128
 
 
 def sha1_hash(data: bytes, d: int = 32) -> int:
@@ -142,4 +144,4 @@ def xxh3_hash(data: bytes, d: int = 32) -> int:
     return int.from_bytes(xxhash.xxh3_128_digest(data)[: d // 8], byteorder="big")
 
 
-__all__ = ["md5", "sha256", "sha1_hash", "xxh3_hash", "xxh3_16hash", "xxh3_32hash"]
+__all__ = ["md5", "sha256", "sha1_hash", "xxh3_64", "xxh3_128", "xxh3_hash", "xxh3_16hash", "xxh3_32hash"]

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -47,6 +47,7 @@ def xxh3_hash(data: bytes, d: int = 32) -> int:
     """
     Generate a d-bit xxhash based hash value from the given data.
     As of python xxhash 3.3.0 (and since 0.3.0) outputs in big-endian.
+    This is useful as a general purpose xxhash that can take multiple `d` values
 
     Parameters
     ----------
@@ -81,3 +82,9 @@ def xxh3_hash(data: bytes, d: int = 32) -> int:
             return xxhash.xxh3_128_intdigest(data)
     # fall back
     return int.from_bytes(xxhash.xxh3_128_digest(data)[: d // 8], byteorder="big")
+
+
+__all__ = [
+    "sha1_hash",
+    "xxh3_hash",
+]

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -1,7 +1,8 @@
 import hashlib
 import struct
 import xxhash
-from xxhash import xxh64_digest, xxh128_digest
+from xxhash import xxh3_64_digest, xxh3_128_digest
+from xxhash import xxh3_128
 
 
 def sha1_hash(data: bytes, d: int = 32) -> int:

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -1,6 +1,7 @@
 import hashlib
 import struct
 import xxhash
+from xxhash import xxh64_digest, xxh128_digest
 
 
 def sha1_hash(data: bytes, d: int = 32) -> int:

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -5,6 +5,7 @@ from hashlib import sha256
 
 import xxhash
 from xxhash import xxh3_64
+from xxhash import xxh3_64_digest
 from xxhash import xxh3_128
 
 

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -1,8 +1,11 @@
 import hashlib
 import struct
 import xxhash
-from xxhash import xxh3_64_digest, xxh3_128_digest
-from xxhash import xxh3_128
+
+from hashlib import md5, sha256
+from blake3 import blake3
+
+from xxhash import xxh3_128, xxh3_64_digest, xxh3_128_digest
 
 
 def sha1_hash(data: bytes, d: int = 32) -> int:

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -43,6 +43,68 @@ def sha1_hash(data: bytes, d: int = 32) -> int:
     return int.from_bytes(hashlib.sha1(data).digest()[: d // 8], byteorder="little")
 
 
+def xxh3_16hash(data: bytes, seed: int = 0) -> int:
+    """
+    Generate a 16-bit xxhash based hash value from the given data.
+    As of python xxhash 3.3.0 (and since 0.3.0) outputs in big-endian.
+    This is useful as a special purpose xxhash when you only want 16 bits.
+    bit masked xxh3_64 hashes are faster than xxh32 in modern systems.
+
+    Parameters
+    ----------
+    data : bytes
+        The data to be hashed.
+    seed : int
+        xxhashes can all be seeded. Default is int=0
+
+    Returns
+    -------
+    int
+        The hash value.
+
+    Examples
+    --------
+    >>> xxh3_16hash(b"hello world")
+    39051
+    >>> xxh3_16hash(b"hello world",seed=42)
+    13198
+    >>> xxh3_16hash(b"hello world",seed=-42)
+    34281
+    """
+    return xxhash.xxh3_64_intdigest(data, seed) & 0xFFFF
+
+
+def xxh3_32hash(data: bytes, seed: int = 0) -> int:
+    """
+    Generate a 32-bit xxhash based hash value from the given data.
+    As of python xxhash 3.3.0 (and since 0.3.0) outputs in big-endian.
+    This is useful as a special purpose xxhash when you only want 32bits.
+    bit masked xxh3_64 hashes are faster than xxh32 in modern systems.
+
+    Parameters
+    ----------
+    data : bytes
+        The data to be hashed.
+    seed : int
+        xxhashes can all be seeded. Default is int=0
+
+    Returns
+    -------
+    int
+        The hash value.
+
+    Examples
+    --------
+    >>> xxh3_32hash(b"hello world")
+    1088854155
+    >>> xxh3_32hash(b"hello world",seed=42)
+    3913102222
+    >>> xxh3_32hash(b"hello world",seed=-42)
+    3721037289
+    """
+    return xxhash.xxh3_64_intdigest(data, seed) & 0xFFFFFFFF
+
+
 def xxh3_hash(data: bytes, d: int = 32) -> int:
     """
     Generate a d-bit xxhash based hash value from the given data.
@@ -84,7 +146,4 @@ def xxh3_hash(data: bytes, d: int = 32) -> int:
     return int.from_bytes(xxhash.xxh3_128_digest(data)[: d // 8], byteorder="big")
 
 
-__all__ = [
-    "sha1_hash",
-    "xxh3_hash",
-]
+__all__ = ["sha1_hash", "xxh3_hash", "xxh3_16hash", "xxh3_32hash"]

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -4,10 +4,6 @@ from hashlib import md5
 from hashlib import sha256
 
 import xxhash
-from xxhash import xxh3_64
-from xxhash import xxh3_64_digest
-from xxhash import xxh3_128
-from xxhash import xxh3_128_digest
 
 
 def sha1_hash(data: bytes, d: int = 32) -> int:
@@ -146,4 +142,4 @@ def xxh3_hash(data: bytes, d: int = 32) -> int:
     return int.from_bytes(xxhash.xxh3_128_digest(data)[: d // 8], byteorder="big")
 
 
-__all__ = ["sha1_hash", "xxh3_hash", "xxh3_16hash", "xxh3_32hash"]
+__all__ = ["md5", "sha256", "sha1_hash", "xxh3_hash", "xxh3_16hash", "xxh3_32hash"]

--- a/text_dedup/utils/hashfunc.py
+++ b/text_dedup/utils/hashfunc.py
@@ -4,7 +4,6 @@ from hashlib import md5
 from hashlib import sha256
 
 import xxhash
-from blake3 import blake3
 from xxhash import xxh3_64
 from xxhash import xxh3_64_digest
 from xxhash import xxh3_128

--- a/text_dedup/utils/preprocess.py
+++ b/text_dedup/utils/preprocess.py
@@ -8,6 +8,7 @@ import regex as re
 DIGIT_RE = re.compile(r"\d")
 PUNCT_OR_NON_PRINTING_CHARS_RE = re.compile(r"[\p{P}\p{C}\p{S}]+")
 
+
 def normalize(line: str) -> str:
     """
     Normalize a line of text. Source: https://github.com/facebookresearch/cc_net/blob/bda555bd1cf1ee2e0b925363e62a61cd46c8b60d/cc_net/text_normalizer.py#L180
@@ -16,7 +17,7 @@ def normalize(line: str) -> str:
     ----------
     line : str
         The line of text to normalize.
-    
+
     Returns
     -------
     str


### PR DESCRIPTION
This will start bit by bit
each commit roughly corresponds to one script (`minhash.py`, `simhash.py` etc)
defaults will remain as current