### PR TITLE
Implement Union by Rank in union_find

### DIFF
--- a/benchmarks/micro/unionfind.ipynb
+++ b/benchmarks/micro/unionfind.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "# from https://snap.stanford.edu/data/soc-Pokec.html\n",
     "# 126MiB compressed, ~400MiB decompressed\n",
-    "wget_command = f'wget https://snap.stanford.edu/data/soc-pokec-relationships.txt.gz -O \"{TEST_DATA_PATH}\"'"
+    "wget_command = f'wget https://snap.stanford.edu/data/soc-pokec-relationships.txt.gz -O \"{TEST_DATA_PATH}.gz\"'"
    ]
   },
   {
@@ -33,7 +33,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!{wget_command}"
+    "# download text.gz\n",
+    "!{wget_command}\n",
+    "# gunzip the text file\n",
+    "!pigz -d {TEST_DATA_PATH}.gz\n"
    ]
   },
   {

--- a/benchmarks/micro/unionfind.ipynb
+++ b/benchmarks/micro/unionfind.ipynb
@@ -8,10 +8,32 @@
    "source": [
     "from text_dedup.utils import UnionFind\n",
     "from text_dedup.utils import RankUnionFind\n",
-    "import os\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare test file from https://snap.stanford.edu/data/soc-Pokec.html\n",
+    "TEST_DATA_DIR = os.path.abspath(\"../data\")\n",
+    "os.makedirs(TEST_DATA_DIR, exist_ok=True)\n",
+    "TEST_DATA_PATH = os.path.join(TEST_DATA_DIR, \"soc-pokec-relationships.txt\")\n",
     "\n",
     "# from https://snap.stanford.edu/data/soc-Pokec.html\n",
-    "TEST_DATA_PATH = os.path.abspath(\"../data/soc-pokec-relationships_1M.txt\")"
+    "# 126MiB compressed, ~400MiB decompressed\n",
+    "wget_command = f'wget https://snap.stanford.edu/data/soc-pokec-relationships.txt.gz -O \"{TEST_DATA_PATH}\"'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!{wget_command}"
    ]
   },
   {
@@ -37,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit -n 1 -r 1\n",
+    "%%timeit -n 1 -r 20\n",
     "uf = process_data(TEST_DATA_PATH, class_=UnionFind)"
    ]
   },

--- a/benchmarks/micro/unionfind.ipynb
+++ b/benchmarks/micro/unionfind.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from text_dedup.utils import UnionFind\n",
+    "from text_dedup.utils import RankUnionFind\n",
+    "import os\n",
+    "\n",
+    "# from https://snap.stanford.edu/data/soc-Pokec.html\n",
+    "TEST_DATA_PATH = os.path.abspath(\"../data/soc-pokec-relationships_1M.txt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def process_data(path, class_=UnionFind):\n",
+    "    uf = class_()\n",
+    "    with open(path) as f:\n",
+    "        for line in f:\n",
+    "            x, y = line.strip().split('\\t')\n",
+    "            x = int(x)\n",
+    "            y = int(y)\n",
+    "            uf.union(x, y)\n",
+    "    return uf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit -n 1 -r 1\n",
+    "uf = process_data(TEST_DATA_PATH, class_=UnionFind)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit -n 1 -r 20\n",
+    "ruf = process_data(TEST_DATA_PATH, class_=RankUnionFind)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rough estimation of the memory usage\n",
+    "import pickle\n",
+    "uf = process_data(TEST_DATA_PATH, class_=UnionFind)\n",
+    "ruf = process_data(TEST_DATA_PATH, class_=RankUnionFind)\n",
+    "\n",
+    "print(len(pickle.dumps(uf)))\n",
+    "print(len(pickle.dumps(ruf)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/benchmarks/micro/unionfind.ipynb
+++ b/benchmarks/micro/unionfind.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "from text_dedup.utils import UnionFind\n",
-    "from text_dedup.utils import RankUnionFind\n",
+    "# from text_dedup.utils import RankUnionFind\n",
     "import os"
    ]
   },
@@ -69,8 +69,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit -n 1 -r 20\n",
-    "ruf = process_data(TEST_DATA_PATH, class_=RankUnionFind)"
+    "# union by rank completely supplants unionfind\n",
+    "#%%timeit -n 1 -r 20\n",
+    "#ruf = process_data(TEST_DATA_PATH, class_=RankUnionFind)"
    ]
   },
   {
@@ -82,10 +83,10 @@
     "# rough estimation of the memory usage\n",
     "import pickle\n",
     "uf = process_data(TEST_DATA_PATH, class_=UnionFind)\n",
-    "ruf = process_data(TEST_DATA_PATH, class_=RankUnionFind)\n",
+    "#ruf = process_data(TEST_DATA_PATH, class_=RankUnionFind)\n",
     "\n",
     "print(len(pickle.dumps(uf)))\n",
-    "print(len(pickle.dumps(ruf)))"
+    "#print(len(pickle.dumps(ruf)))"
    ]
   }
  ],

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -26,7 +26,6 @@ from datasets import load_from_disk
 from tqdm import tqdm
 
 from text_dedup import logger
-from text_dedup.utils import RankUnionFind
 from text_dedup.utils import UnionFind
 from text_dedup.utils import ngrams
 from text_dedup.utils.add_args import add_io_args
@@ -184,10 +183,7 @@ if __name__ == "__main__":  # pragma: no cover
     # is not copied to child processes as long as it is not modified.
     mp.set_start_method("fork", force=True)
 
-    if not args.rank_unionfind:
-        uf = UnionFind()
-    else:
-        uf = RankUnionFind()  # type: ignore
+    uf = UnionFind()
     timer = Timer()
 
     if args.b is not None and args.r is not None:

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -26,6 +26,7 @@ from datasets import load_from_disk
 from tqdm import tqdm
 
 from text_dedup import logger
+from text_dedup.utils import RankUnionFind
 from text_dedup.utils import UnionFind
 from text_dedup.utils import ngrams
 from text_dedup.utils.add_args import add_io_args
@@ -182,7 +183,11 @@ if __name__ == "__main__":  # pragma: no cover
     # for is originally used to reduce memory usage in MacOS but also ensures that the Union Find data structure
     # is not copied to child processes as long as it is not modified.
     mp.set_start_method("fork", force=True)
-    uf = UnionFind()
+
+    if not args.rank_unionfind:
+        uf = UnionFind()
+    else:
+        uf = RankUnionFind()  # type: ignore
     timer = Timer()
 
     if args.b is not None and args.r is not None:

--- a/text_dedup/simhash.py
+++ b/text_dedup/simhash.py
@@ -28,6 +28,7 @@ from datasets import load_from_disk
 from tqdm import tqdm
 
 from text_dedup import logger
+from text_dedup.utils import RankUnionFind
 from text_dedup.utils import UnionFind
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
@@ -341,7 +342,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     mp.set_start_method("fork", force=True)
-    uf = UnionFind()
+
+    if not args.rank_unionfind:
+        uf = UnionFind()
+    else:
+        uf = RankUnionFind()  # type: ignore
+
     timer = Timer()
     PERMUTATIONS = _create_permutations(args.f, k=args.bit_diff, b=args.num_bucket)
     BUCKETS: Dict[Any, List] = defaultdict(list)

--- a/text_dedup/simhash.py
+++ b/text_dedup/simhash.py
@@ -28,7 +28,6 @@ from datasets import load_from_disk
 from tqdm import tqdm
 
 from text_dedup import logger
-from text_dedup.utils import RankUnionFind
 from text_dedup.utils import UnionFind
 from text_dedup.utils import add_io_args
 from text_dedup.utils import add_meta_args
@@ -343,10 +342,7 @@ if __name__ == "__main__":
 
     mp.set_start_method("fork", force=True)
 
-    if not args.rank_unionfind:
-        uf = UnionFind()
-    else:
-        uf = RankUnionFind()  # type: ignore
+    uf = UnionFind()
 
     timer = Timer()
     PERMUTATIONS = _create_permutations(args.f, k=args.bit_diff, b=args.num_bucket)

--- a/text_dedup/utils/__init__.py
+++ b/text_dedup/utils/__init__.py
@@ -14,6 +14,7 @@ from text_dedup.utils.hashfunc import sha1_hash
 from text_dedup.utils.hashfunc import xxh3_hash
 from text_dedup.utils.timer import Timer
 from text_dedup.utils.tokenization import ngrams
+from text_dedup.utils.union_find import RankUnionFind
 from text_dedup.utils.union_find import UnionFind
 
 __all__ = [
@@ -27,6 +28,7 @@ __all__ = [
     "Timer",
     "ngrams",
     "UnionFind",
+    "RankUnionFind",
     "sha1_hash",
     "xxh3_hash",
 ]

--- a/text_dedup/utils/__init__.py
+++ b/text_dedup/utils/__init__.py
@@ -14,7 +14,6 @@ from text_dedup.utils.hashfunc import sha1_hash
 from text_dedup.utils.hashfunc import xxh3_hash
 from text_dedup.utils.timer import Timer
 from text_dedup.utils.tokenization import ngrams
-from text_dedup.utils.union_find import RankUnionFind
 from text_dedup.utils.union_find import UnionFind
 
 __all__ = [
@@ -28,7 +27,6 @@ __all__ = [
     "Timer",
     "ngrams",
     "UnionFind",
-    "RankUnionFind",
     "sha1_hash",
     "xxh3_hash",
 ]

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -131,14 +131,6 @@ def add_minhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         this is due to legacy reasons. refer to ekzhu/datasketch#212.
         """,
     ),
-    parser.add_argument(
-        "--rank_unionfind",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="""During clustering and filtering we use Union Find with path compression.
-        Setting this adds Union by rank which might improve behavior at this step.
-        Pickled version becomes mutually incompatible and doubles saved size""",
-    ),
 
     return parser
 
@@ -167,13 +159,6 @@ def add_simhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
     parser.add_argument("--bit_diff", type=int, default=3, help="Bit difference to use in SimHash"),
     parser.add_argument(
         "--num_bucket", type=int, default=4, help="Number of buckets to use in SimHash, must be larger than bit_diff"
-    ),
-    parser.add_argument(
-        "--rank_unionfind",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="""During clustering and filtering we use Union Find with path compression.
-        Setting this adds Union by rank to further improve scaling at this step.""",
     ),
 
     return parser

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -130,7 +130,14 @@ def add_minhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         However, even when using 64bit precision, only 32 bits are extracted from hash.
         this is due to legacy reasons. refer to ekzhu/datasketch#212.
         """,
-    )
+    ),
+    parser.add_argument(
+        "--rank_unionfind",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="""During clustering and filtering we use Union Find with path compression.
+        Setting this adds Union by rank to further improve scaling at this step.""",
+    ),
 
     return parser
 
@@ -160,6 +167,14 @@ def add_simhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
     parser.add_argument(
         "--num_bucket", type=int, default=4, help="Number of buckets to use in SimHash, must be larger than bit_diff"
     ),
+    parser.add_argument(
+        "--rank_unionfind",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="""During clustering and filtering we use Union Find with path compression.
+        Setting this adds Union by rank to further improve scaling at this step.""",
+    ),
+
     return parser
 
 

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -136,7 +136,8 @@ def add_minhash_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         action=argparse.BooleanOptionalAction,
         default=False,
         help="""During clustering and filtering we use Union Find with path compression.
-        Setting this adds Union by rank to further improve scaling at this step.""",
+        Setting this adds Union by rank which might improve behavior at this step.
+        Pickled version becomes mutually incompatible and doubles saved size""",
     ),
 
     return parser

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -109,12 +109,15 @@ class RankUnionFind:
         # The line in original UnionFind `self.parent[px] = self.parent[py] = min(px, py)` is redundant when px == py
         if px == py:
             return
-        # Attach the smaller rank tree under the root of the larger rank tree
-        if self.rank[px] < self.rank[py]:
-            self.parent[px] = py
-        elif self.rank[px] > self.rank[py]:
-            self.parent[py] = px
-        else:
+
+        if self.rank[px] == self.rank[py]:
             # If ranks are equal, choose one as the new root and increment its rank
+            # with few duplicates this is likely to be the most common case
             self.parent[py] = px
             self.rank[px] += 1
+        # otherwise, assume that leftside is more likely to be higher rank
+        # Attach the smaller rank tree under the root of the larger rank tree
+        elif self.rank[px] > self.rank[py]:
+            self.parent[py] = px
+        elif self.rank[px] < self.rank[py]:
+            self.parent[px] = py

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -119,5 +119,5 @@ class RankUnionFind:
         # Attach the smaller rank tree under the root of the larger rank tree
         elif self.rank[px] > self.rank[py]:
             self.parent[py] = px
-        elif self.rank[px] < self.rank[py]:
+        else:
             self.parent[px] = py

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -96,6 +96,7 @@ class RankUnionFind:
             if self.parent[x] != x:
                 self.parent[x] = self.find(self.parent[x])
         except KeyError:
+            # KeyError happens if x not in parent
             self.parent[x] = x
         finally:
             return self.parent[x]

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -52,7 +52,6 @@ class RankUnionFind:
     Applying either union by rank or path compression results in a time complexity of O( log (n) ) each.
     Applying both further reduces this to O( inverse_ackermann (n) )
     (inverse ackermann is a very slow growing function.)
-    The size of the additional rank also grows at O (log log (n)) .
 
 
     Examples

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -87,7 +87,7 @@ class RankUnionFind:
     def __init__(self):
         self.parent = {}
         # Counter is a subclass of dict with slightly different python and c implementations
-        # you think of it as an optimized defaultdict(int)
+        # you can think of it as an optimized defaultdict(int)
         self.rank = Counter()
 
     def find(self, x):

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # @Date    : 2022-12-26 15:37:44
 # @Author  : Chenghao Mou (mouchenghao@gmail.com)
+from collections import Counter
 
 
 class UnionFind:
@@ -85,12 +86,11 @@ class RankUnionFind:
 
     def __init__(self):
         self.parent = {}
-        self.rank = {}
+        self.rank = Counter()
 
     def find(self, x):
         if x not in self.parent:
             self.parent[x] = x
-            self.rank[x] = 0
             return x
 
         # path compression

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -86,11 +86,15 @@ class RankUnionFind:
 
     def __init__(self):
         self.parent = {}
+        # Counter is a subclass of dict with slightly different python and c implementations
+        # you think of it as an optimized defaultdict(int)
         self.rank = Counter()
 
     def find(self, x):
         if x not in self.parent:
             self.parent[x] = x
+            # the following line becomes unnecessary saving time and space
+            # self.rank[x] = x
             return x
 
         # path compression

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -43,3 +43,77 @@ class UnionFind:
         px = self.find(x)
         py = self.find(y)
         self.parent[px] = self.parent[py] = min(px, py)
+
+
+class RankUnionFind:
+    """
+    A data structure for maintaining disjoint sets. This helps build connected components for given duplicate pairs.
+    This version uses rank structure alongside path compression. (Union by Rank)
+    Applying either union by rank or path compression results in a time complexity of O( log (n) ) each.
+    Applying both further reduces this to O( inverse_ackermann (n) )
+    (inverse ackermann is a very slow growing function.)
+    The size of the additional rank also grows at O (log log (n)) .
+
+
+    Examples
+    --------
+    >>> ruf = RankUnionFind()
+    >>> ruf.union(1, 2)
+    >>> ruf.union(2, 3)
+    >>> ruf.union(4, 5)
+    >>> ruf.find(1)
+    1
+    >>> ruf.find(2)
+    1
+    >>> ruf.find(3)
+    1
+    >>> ruf.find(4)
+    4
+    >>> ruf.find(5)
+    4
+    >>> ruf.rank[1]
+    1
+    >>> ruf.rank[2]
+    0
+    >>> ruf.union(3, 4)
+    >>> ruf.find(1) == ruf.find(5) == 1
+    True
+    >>> ruf.find(7)
+    7
+    >>> ruf.rank[7]
+    0
+    """
+
+    def __init__(self):
+        self.parent = {}
+        self.rank = {}
+
+    def find(self, x):
+        if x not in self.parent:
+            self.parent[x] = x
+            self.rank[x] = 0
+            return x
+
+        # path compression
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+
+        return self.parent[x]
+
+    def union(self, x, y):
+        px = self.find(x)
+        py = self.find(y)
+
+        # If both elements are already in the same set, do nothing
+        # The line in original UnionFind `self.parent[px] = self.parent[py] = min(px, py)` is redundant when px == py
+        if px == py:
+            return
+        # Attach the smaller rank tree under the root of the larger rank tree
+        if self.rank[px] < self.rank[py]:
+            self.parent[px] = py
+        elif self.rank[px] > self.rank[py]:
+            self.parent[py] = px
+        else:
+            # If ranks are equal, choose one as the new root and increment its rank
+            self.parent[py] = px
+            self.rank[px] += 1

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -8,6 +8,11 @@ from collections import Counter
 class UnionFind:
     """
     A data structure for maintaining disjoint sets. This helps build connected components for given duplicate pairs.
+    This version uses both rank structure (Union by Rank) and path compression.
+    Applying either union by rank or path compression results in a time complexity of O( log (n) ) each.
+    Applying both further reduces this to O( inverse_ackermann (n) )
+    (inverse ackermann is a very slow growing function.)
+
 
     Examples
     --------
@@ -25,62 +30,16 @@ class UnionFind:
     4
     >>> uf.find(5)
     4
-    """
-
-    def __init__(self):
-        self.parent = {}
-
-    def find(self, x):
-        if x not in self.parent:
-            self.parent[x] = x
-            return x
-
-        if self.parent[x] != x:
-            self.parent[x] = self.find(self.parent[x])
-
-        return self.parent[x]
-
-    def union(self, x, y):
-        px = self.find(x)
-        py = self.find(y)
-        self.parent[px] = self.parent[py] = min(px, py)
-
-
-class RankUnionFind:
-    """
-    A data structure for maintaining disjoint sets. This helps build connected components for given duplicate pairs.
-    This version uses rank structure alongside path compression. (Union by Rank)
-    Applying either union by rank or path compression results in a time complexity of O( log (n) ) each.
-    Applying both further reduces this to O( inverse_ackermann (n) )
-    (inverse ackermann is a very slow growing function.)
-
-
-    Examples
-    --------
-    >>> ruf = RankUnionFind()
-    >>> ruf.union(1, 2)
-    >>> ruf.union(2, 3)
-    >>> ruf.union(4, 5)
-    >>> ruf.find(1)
+    >>> uf.rank[1]
     1
-    >>> ruf.find(2)
-    1
-    >>> ruf.find(3)
-    1
-    >>> ruf.find(4)
-    4
-    >>> ruf.find(5)
-    4
-    >>> ruf.rank[1]
-    1
-    >>> ruf.rank[2]
+    >>> uf.rank[2]
     0
-    >>> ruf.union(3, 4)
-    >>> ruf.find(1) == ruf.find(5) == 1
+    >>> uf.union(3, 4)
+    >>> uf.find(1) == uf.find(5) == 1
     True
-    >>> ruf.find(7)
+    >>> uf.find(7)
     7
-    >>> ruf.rank[7]
+    >>> uf.rank[7]
     0
     """
 

--- a/text_dedup/utils/union_find.py
+++ b/text_dedup/utils/union_find.py
@@ -91,17 +91,14 @@ class RankUnionFind:
         self.rank = Counter()
 
     def find(self, x):
-        if x not in self.parent:
+        try:
+            # path compression
+            if self.parent[x] != x:
+                self.parent[x] = self.find(self.parent[x])
+        except KeyError:
             self.parent[x] = x
-            # the following line becomes unnecessary saving time and space
-            # self.rank[x] = x
-            return x
-
-        # path compression
-        if self.parent[x] != x:
-            self.parent[x] = self.find(self.parent[x])
-
-        return self.parent[x]
+        finally:
+            return self.parent[x]
 
     def union(self, x, y):
         px = self.find(x)


### PR DESCRIPTION
Although I spent quite some time implementing this and testing this,
I would not be upset if it was rejected outright.

It seems that for most datasets that I encounter, unionfind with path compression is good enough.

I suspect that for certain pathological datasets with high exact duplicates or near duplicates this might be relevant.
False positive / False negative ratios might also be a factor in how the union grows.
Or maybe it would be relevent in much larger scales, but in that case we would be paying the cost for the Union by Rank in this case as well. (Rank does have extremely favorable scaling characteristics though)

But it is unclear if this should implemented when it is not yet clear at this time. 
On the otherhand, having another lever for customization/optimization can always be helpful.

If you feel that the additional engineering and complexity cost is too much, I will maintain this as a branch that could be reapplied for a PR when it seems to become necessary. 

