### PR TITLE
Doublehash minhash

### DIFF
--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import argparse
 import gc
-import hashlib
 import multiprocessing as mp
 import os
 import pickle
@@ -14,7 +13,6 @@ import random
 import re
 from collections import defaultdict
 from typing import Any
-from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Set

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -34,8 +34,6 @@ from text_dedup.utils.add_args import add_meta_args
 from text_dedup.utils.add_args import add_minhash_args
 from text_dedup.utils.analysis import optimal_param
 from text_dedup.utils.hashfunc import sha1_hash
-from text_dedup.utils.hashfunc import xxh3_16hash
-from text_dedup.utils.hashfunc import xxh3_32hash
 from text_dedup.utils.hashfunc import xxh3_hash
 from text_dedup.utils.timer import Timer
 
@@ -53,8 +51,6 @@ def embed_func(
     ngram_size: int,
     min_length: int,
     hashranges: List[Tuple[int, int]],
-    permutations: np.ndarray,
-    hash_func: Callable,
     dtype: type,
     max_hash: np.uint,
     modulo_prime: np.uint,
@@ -95,41 +91,28 @@ def embed_func(
     >>> hashranges = [(i, i + 25) for i in range(0, 250, 25)]
     >>> max_hash = np.uint32((1 << 32) - 1)
     >>> modulo_prime = np.uint32((1 << 32) - 5)
-    >>> PERMUTATIONS = np.array(
-    ...     [
-    ...         (
-    ...             RNG.randint(1, np.uint32((1 << 32) - 5), dtype=np.uint32),
-    ...             RNG.randint(0, np.uint32((1 << 32) - 5), dtype=np.uint32),
-    ...         )
-    ...         for _ in range(num_perm)
-    ...     ],
-    ...     dtype=np.uint32,
-    ... ).T
     >>> res = embed_func(content, idx, num_perm=num_perm, ngram_size=ngram_size, min_length=0, hashranges=hashranges,
-    ... permutations=PERMUTATIONS, hash_func=xxh3_32hash,dtype=np.uint32, max_hash=max_hash, modulo_prime=modulo_prime)
+    ... hash_func=xxh3_32hash,dtype=np.uint32, max_hash=max_hash, modulo_prime=modulo_prime)
     >>> len(res["__signatures__"])
     10
     >>> res["__id__"]
     0
     """
-    # a, b are each np.ndarray arrays containing {num_perm} pairs of random numbers used for building new hashes
-    # the formula is a * x(base hash of each shingle) + b
-    a, b = permutations
     # split content on whitespace (NON_ALPHA regex), tokenize with ngrams(), and join these n-grams into a single space separated string.
     # we then convert to lower case and then bytestrings which is then hashed. Only unique hashed n-grams are left.
     tokens: Set[bytes] = {
         bytes(" ".join(t).lower(), "utf-8") for t in ngrams(NON_ALPHA.split(content), ngram_size, min_length)
     }
 
-    hashes_1: np.ndarray = np.array([xxh3_hash(token, HASH_BITS) for token in tokens], dtype=dtype, ndmin=2).T
-    hashes_2: np.ndarray = np.array([sha1_hash(token, HASH_BITS) for token in tokens], dtype=dtype, ndmin=2).T
-    i: np.ndarray = np.arange(num_perm, dtype=dtype).reshape((1, num_perm))
+    hashes_1: np.ndarray = np.array([sha1_hash(token, HASH_BITS) for token in tokens], dtype=dtype, ndmin=2).T
+    hashes_2: np.ndarray = np.array([xxh3_hash(token, HASH_BITS) for token in tokens], dtype=dtype, ndmin=2).T
+    index: np.ndarray = np.arange(num_perm, dtype=dtype).reshape((1, num_perm))
     # Permute the hash values to produce new universal hashes
-    hashvalues = np.mod(hashes_1 + i * hashes_2 + i**2, modulo_prime, dtype=dtype)
+    hashvalues = (hashes_1 + index * hashes_2 + index**2) % modulo_prime
 
     # this part is where the name "min" of minhash comes from
     # this stacks all the hashes and then takes the minimum from each column
-    masks: np.ndarray = np.full(shape=num_perm, dtype=dtype, fill_value=max_hash)
+    masks: np.ndarray = np.full(shape=num_perm, fill_value=max_hash)
     hashvalues = np.vstack([hashvalues, masks]).min(axis=0)
     # Originally, byteswap was done for speed. Testing show it has a negligible impact
     # keeping  for backward compatibility, even though theoretically and empirically
@@ -156,7 +139,7 @@ if __name__ == "__main__":  # pragma: no cover
     # why legacy implementations used mersenne primes for modulo:
     # https://en.wikipedia.org/wiki/Universal_hashing#Hashing_strings
     HASH_CONFIG: Dict[int, Tuple[type, Any, Any]] = {
-        64: (np.uint64, np.uint64((1 << 32) - 1), np.uint64((1 << 61) - 1)),
+        64: (np.uint64, np.uint32((1 << 32) - 1), np.uint64((1 << 61) - 1)),
         # 32, 16 bit config does not use a mersenne prime.
         # The original reason for using mersenne prime was speed.
         # Testing reveals, there is no benefit to using a 2^61 mersenne prime for division
@@ -166,18 +149,6 @@ if __name__ == "__main__":  # pragma: no cover
 
     # defaults to backwards compatible HASH_BITS = 64, which is np.uint64 dtypes with 32bit hashes
     DTYPE, MAX_HASH, MODULO_PRIME = HASH_CONFIG.get(HASH_BITS, HASH_CONFIG[64])
-
-    match args.hash_func:
-        case "sha1":
-
-            def hash_func(byte_data):
-                return sha1_hash(byte_data, d=min(HASH_BITS, 32))
-
-        case "xxh3":
-            if HASH_BITS == 16:
-                hash_func = xxh3_16hash
-            else:
-                hash_func = xxh3_32hash
 
     # for is originally used to reduce memory usage in MacOS but also ensures that the Union Find data structure
     # is not copied to child processes as long as it is not modified.
@@ -219,21 +190,8 @@ if __name__ == "__main__":  # pragma: no cover
 
         LEN_DATASET = len(ds)
         # for minhash, we need to make a lot of hashes(=num_perms).
-        # In many previous implementations, this is achieved through a method described in
-        # `Universal classes of hash functions` https://doi.org/10.1016/0022-0000(79)90044-8
-        # There we start with a know good hash x (=hash_func) and permutate it as the following:
-        # `new_hash = (a * x + b) mod prime mod max_hash` we need one a (!=0), b pair per new hash
-        # the following produces these a, b pairs
-        PERMUTATIONS: np.ndarray = np.array(
-            [
-                (
-                    RNG.randint(1, MODULO_PRIME, dtype=DTYPE),  # a is a multiplier so should not be 0
-                    RNG.randint(0, MODULO_PRIME, dtype=DTYPE),  # b
-                )
-                for _ in range(args.num_perm)
-            ],
-            dtype=DTYPE,
-        ).T
+        # In this implementation we are using enhanced doublehash
+        # https://en.wikipedia.org/wiki/Double_hashing
 
         with timer("MinHashing"):
             embedded = ds.map(
@@ -243,8 +201,6 @@ if __name__ == "__main__":  # pragma: no cover
                     "hashranges": HASH_RANGES,
                     "ngram_size": args.ngram,
                     "min_length": args.min_length,
-                    "permutations": PERMUTATIONS,
-                    "hash_func": hash_func,
                     "dtype": DTYPE,
                     "max_hash": MAX_HASH,
                     "modulo_prime": MODULO_PRIME,

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":  # pragma: no cover
     }
 
     # defaults to backwards compatible HASH_BITS = 64, which is np.uint64 dtypes with 32bit hashes
-    DTYPE, MAX_HASH, MODULO_PRIME = HASH_CONFIG.get(HASH_BITS, HASH_CONFIG[64])
+    DTYPE, MAX_HASH, MODULO_PRIME = HASH_CONFIG.get(HASH_BITS, HASH_CONFIG[32])
 
     # for is originally used to reduce memory usage in MacOS but also ensures that the Union Find data structure
     # is not copied to child processes as long as it is not modified.

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -110,7 +110,7 @@ def embed_func(
 
     # this part is where the name "min" of minhash comes from
     # this stacks all the hashes and then takes the minimum from each column
-    masks: np.ndarray = np.full(shape=num_perm, fill_value=max_hash)
+    masks: np.ndarray = np.full(shape=num_perm, dtype=dtype, fill_value=max_hash)
     hashvalues = np.vstack([hashvalues, masks]).min(axis=0)
     # Originally, byteswap was done for speed. Testing show it has a negligible impact
     # keeping  for backward compatibility, even though theoretically and empirically


### PR DESCRIPTION
**I do not expect this to completely replace the current minhash.**

Bloom filters also require a lot of random hashes for the purposes of their bit mask.
In their case they utilize a different methods of minimizing hash operations.
one of which is to take 2 known good hashes and permutating between them.

Our current hash derivation is as follows 
` (a * h(x) + b mod p) mod m` where x is an input to hash function h(), p is a big prime, and m is the universe size. a and b are random numbers, 1 per each hash we want.

(enhanced) Double hash is as follows

`dbh(x,i)  = ( h1(x) + i * h2(x) + f(i) mod m )` where h1,h2() are good hashes, i is an index (0 to m-1), f(i) is a function of i that can "repair" any degradations of hash quality due of the original double hash.

Most qualifications and studies are regarding bloom hash and load factors (collision when using double hash as an index generator for a table).
However, when h1 and h2 are both universal hashes, then dbh(x,i) is also within a class of universal hashes.

There are many papers on this but this one is particulary good explaining it and how it relates to count-min sketches
(for example a minhash)
https://www.eecs.harvard.edu/~michaelm/postscripts/rsa2008.pdf
(enhanced double hash is described in section 5.2 page 199 or 13/32 of the pdf)
how it relates to count-min sketches : section 9, page 214, 28/32 of the pdf

This paper discusses more on the theoretical background of hashing and how it relates to universal hashes and double hashes
https://www.cs.unc.edu/~baruah/Teaching/2017-1Sp/RestrictedAccess/LECTURES/L20-slides.pdf

Empirical data on real world data "good enough" for me
Pinecone results :
```
results of pinecone at 32 bits
{'Correct': 90320,
 'Incorrect': 9680,
 'Accuracy': 0.9032,
 'Recall': 0.9659,
 'Precision': 0.4357}
```

Compared to the previous implementation, one quality might be the most important reason I implemented this in the first place.
We no longer have to include the `PERMUTATIONS` numpy object containing random multipliers and addors (a,b) into the embedding function. 

`i` or the `index` can be derived from the index (as long as it is under max_hash it does not matter) and we can choose from a predetermined h1,h2, f(i) (usually i**2).

This way the embedding function can be much more simplified.
Anyway although I find this version interesting, it is more to be meant as a platform to implement a Rust (or Cython) based foreign function that we can easily call.

If there is actual interest into integrating this let me know what kind of changes you'd like.

I would imagine this should exist alongside minhash or as an option within.
Maybe we could extract the embed function declarations into a utility function where we can test more out.