### PR TITLE
Replaced os.cpu_count() as a CLI argument

### DIFF
--- a/text_dedup/bloom_filter.py
+++ b/text_dedup/bloom_filter.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":  # pragma: no cover
                 revision=args.revision,
                 cache_dir=args.cache_dir,
                 token=args.use_auth_token,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
             )
 
         hash_func: Callable = {
@@ -78,7 +78,7 @@ if __name__ == "__main__":  # pragma: no cover
             ds = ds.filter(
                 lambda _, idx: not flags[idx],
                 with_indices=True,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
                 desc="Filtering...",
             )
 

--- a/text_dedup/ccnet.py
+++ b/text_dedup/ccnet.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":  # pragma: no cover
                 revision=args.revision,
                 cache_dir=args.cache_dir,
                 token=args.use_auth_token,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
             )
 
         def md5_digest_sized(data: bytes) -> bytes:
@@ -144,7 +144,7 @@ if __name__ == "__main__":  # pragma: no cover
                 batched=True,
                 batch_size=1,
                 with_indices=True,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
                 fn_kwargs={"column": args.column, "hash_func": hash_func},
                 remove_columns=ds.column_names,
                 desc="Computing hashes...",
@@ -167,11 +167,11 @@ if __name__ == "__main__":  # pragma: no cover
             ds = ds.map(
                 dedup,
                 with_indices=True,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
                 fn_kwargs={"column": args.column, "lookup": remove},
                 desc="Deduping",
             )
-            ds = ds.filter(lambda x: len(x[args.column]) > 0, num_proc=os.cpu_count(), desc="Filtering 0 length docs")
+            ds = ds.filter(lambda x: len(x[args.column]) > 0, num_proc=args.num_proc, desc="Filtering 0 length docs")
 
         with timer("Saving"):
             ds.save_to_disk(args.output)

--- a/text_dedup/exact_hash.py
+++ b/text_dedup/exact_hash.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":  # pragma: no cover
     parser = add_exact_hash_args(parser)
     args = parser.parse_args()
 
-    NUM_PROC = os.cpu_count()
+    NUM_PROC = args.num_proc
     timer = Timer()
 
     with timer("Total"):

--- a/text_dedup/minhash.py
+++ b/text_dedup/minhash.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":  # pragma: no cover
                     split=args.split,
                     revision=args.revision,
                     cache_dir=args.cache_dir,
-                    num_proc=os.cpu_count(),
+                    num_proc=args.num_proc,
                     token=args.use_auth_token,
                 )
 
@@ -233,7 +233,7 @@ if __name__ == "__main__":  # pragma: no cover
                 },
                 input_columns=[args.column],
                 remove_columns=ds.column_names,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
                 with_indices=True,
                 desc="Fingerprinting...",
             )
@@ -269,7 +269,7 @@ if __name__ == "__main__":  # pragma: no cover
             ds = ds.map(
                 function=lambda _, idx: {"__cluster__": uf.find(idx)},
                 with_indices=True,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
                 new_fingerprint=str(random.getrandbits(128)),
                 desc="Finding clusters...",
             )
@@ -281,7 +281,7 @@ if __name__ == "__main__":  # pragma: no cover
             final_data = ds.filter(
                 function=lambda record, idx: record["__cluster__"] == idx,
                 with_indices=True,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
                 desc="Filtering clusters...",
             )
 

--- a/text_dedup/simhash.py
+++ b/text_dedup/simhash.py
@@ -364,7 +364,7 @@ if __name__ == "__main__":
                     split=args.split,
                     revision=args.revision,
                     cache_dir=args.cache_dir,
-                    num_proc=os.cpu_count(),
+                    num_proc=args.num_proc,
                     token=args.use_auth_token,
                 )
 
@@ -380,7 +380,7 @@ if __name__ == "__main__":
                 },
                 input_columns=[args.column],
                 remove_columns=[args.column],
-                num_proc=os.cpu_count(),  # type: ignore
+                num_proc=args.num_proc,  # type: ignore
                 with_indices=True,
                 desc="SimHashing...",  # type: ignore
             )
@@ -430,7 +430,7 @@ if __name__ == "__main__":
             ds = ds.map(
                 function=lambda _, idx: {"__cluster__": uf.find(idx)},
                 with_indices=True,
-                num_proc=os.cpu_count(),  # type: ignore
+                num_proc=args.num_proc,  # type: ignore
                 new_fingerprint=str(random.getrandbits(128)),  # type: ignore
                 desc="Finding clusters...",  # type: ignore
             )
@@ -442,7 +442,7 @@ if __name__ == "__main__":
             final_data = ds.filter(
                 function=lambda record, idx: record["__cluster__"] == idx,
                 with_indices=True,
-                num_proc=os.cpu_count(),
+                num_proc=args.num_proc,
                 desc="Filtering clusters...",
             )
 

--- a/text_dedup/suffix_array.py
+++ b/text_dedup/suffix_array.py
@@ -333,7 +333,7 @@ if __name__ == "__main__":
         with timer("SelfSimilar"):
             __run_command(
                 f"cargo run self-similar --data-file {temp_text}"
-                f" --length-threshold {args.k} --cache-dir {args.cache_dir} --num-threads {os.cpu_count()}",
+                f" --length-threshold {args.k} --cache-dir {args.cache_dir} --num-threads {args.num_proc}",
                 args.google_repo_path,
             )
             __run_command(

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -3,6 +3,7 @@
 # @Date    : 2022-11-05 09:16:34
 # @Author  : Chenghao Mou (mouchenghao@gmail.com)
 import argparse
+import os
 
 
 def add_io_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # pragma: no cover
@@ -36,6 +37,11 @@ def add_io_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
     )
     parser.add_argument(
         "--clean_cache", action=argparse.BooleanOptionalAction, help="Whether to remove all cache files", default=True
+    )
+    parser.add_argument(
+        "--num_proc", type=int,
+        help="Number of processes. Defaults to the system CPU count from os.cpu_count()",
+        default=os.cpu_count()
     )
     return parser
 


### PR DESCRIPTION
This PR replaces every `os.cpu_count()` as CLI argument, which sets the number of processes (e.g. `num_proc=` in the many HF datasets methods), for limiting the number of processes.