### PR TITLE
Enable ulimit and tokenize flag in suffix_array.py

### DIFF
--- a/text_dedup/suffix_array.py
+++ b/text_dedup/suffix_array.py
@@ -325,9 +325,9 @@ if __name__ == "__main__":
 
         with timer("SuffixArray"):
             __run_command(
-                f"python scripts/make_suffix_array.py {temp_text}",
-                args.google_repo_path,
-                " ulimit -Sn 1000000" if args.use_ulimit else ""
+                f"python scripts/make_suffix_array.py {temp_text}"
+                " ulimit -Sn 1000000" if args.use_ulimit else "",
+                args.google_repo_path
             )
 
         with timer("SelfSimilar"):

--- a/text_dedup/suffix_array.py
+++ b/text_dedup/suffix_array.py
@@ -327,7 +327,7 @@ if __name__ == "__main__":
             __run_command(
                 f"python scripts/make_suffix_array.py {temp_text}"
                 f"{' ulimit -Sn 100000' if args.use_ulimit else ''}"
-                f"{' --tokenize' if args.use_tokenizer else ''},
+                f"{' --tokenize' if args.use_tokenizer else ''}",
                 args.google_repo_path
             )
 

--- a/text_dedup/suffix_array.py
+++ b/text_dedup/suffix_array.py
@@ -327,6 +327,7 @@ if __name__ == "__main__":
             __run_command(
                 f"python scripts/make_suffix_array.py {temp_text}",
                 args.google_repo_path,
+                " ulimit -Sn 1000000" if args.use_ulimit else ""
             )
 
         with timer("SelfSimilar"):

--- a/text_dedup/suffix_array.py
+++ b/text_dedup/suffix_array.py
@@ -326,8 +326,8 @@ if __name__ == "__main__":
         with timer("SuffixArray"):
             __run_command(
                 f"python scripts/make_suffix_array.py {temp_text}"
-                " ulimit -Sn 1000000" if args.use_ulimit else ""
-                " --tokenize" if args.use_tokenizer else "",
+                f"{' ulimit -Sn 100000' if args.use_ulimit else ''}"
+                f"{' --tokenize' if args.use_tokenizer else ''},
                 args.google_repo_path
             )
 

--- a/text_dedup/suffix_array.py
+++ b/text_dedup/suffix_array.py
@@ -326,7 +326,8 @@ if __name__ == "__main__":
         with timer("SuffixArray"):
             __run_command(
                 f"python scripts/make_suffix_array.py {temp_text}"
-                " ulimit -Sn 1000000" if args.use_ulimit else "",
+                " ulimit -Sn 1000000" if args.use_ulimit else ""
+                " --tokenize" if args.use_tokenizer else "",
                 args.google_repo_path
             )
 

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -194,6 +194,7 @@ def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
         overlapping: Merge all overlapping duplicate substrings
         longest: Only keep the longest duplicate substring
     - google_repo_path: Path to google-research-deduplication codebase, required
+    - use_ulimit: Whether to use `ulimit -Sn 1000000`
 
     Parameters
     ----------
@@ -219,6 +220,12 @@ def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
         default="overlapping",
         help="Strategy when there are overlapping duplicate substrings",
         choices=["overlapping", "longest"],
+    )
+    parser.add_argument(
+        "--use_ulimit",
+        type=bool,
+        default=False,
+        help="Whether to use `ulimit -Sn 1000000`"
     )
     (
         parser.add_argument(

--- a/text_dedup/utils/add_args.py
+++ b/text_dedup/utils/add_args.py
@@ -195,6 +195,7 @@ def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
         longest: Only keep the longest duplicate substring
     - google_repo_path: Path to google-research-deduplication codebase, required
     - use_ulimit: Whether to use `ulimit -Sn 1000000`
+    - use_tokenizer: Whether to use GPT2 tokenizer
 
     Parameters
     ----------
@@ -226,6 +227,12 @@ def add_sa_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:  # 
         type=bool,
         default=False,
         help="Whether to use `ulimit -Sn 1000000`"
+    )
+    parser.add_argument(
+        "--use_tokenizer",
+        type=bool,
+        default=False,
+        help="Whether to use GPT2 Tokenizer"
     )
     (
         parser.add_argument(


### PR DESCRIPTION
If the dataset is really big, you might want to add the --tokenize flag. This will shrink the dataset by roughly a factor of two by tokenizing it with the GPT-2 tokenizer.

(When running on larger files, if you get an error that you have too many open files, that's because this script opens lots of files. You should run ulimit -Sn 1000000 to "fix" the error. You might want to do this preemptively before hitting this crash after hour ten of the job.)

^^^based on the [original repo](https://github.com/google-research/deduplicate-text-datasets/tree/master)