### PR TITLE
Update submodule path for deduplicate-text-datasets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "deduplicate-text-datasets"]
-path = deduplicate-text-datasets
+path = third_party/deduplicate-text-datasets
 url = https://github.com/google-research/deduplicate-text-datasets.git
 ignore = all


### PR DESCRIPTION
Commit 00b6d70 ("add rust uf") moved the deduplicate-text-datasets submodule into third_party/ but didn't update .gitmodules to reflect the new path. This breaks git submodule update --init --recursive for anyone cloning the repo.