### PR TITLE
Fix: accurate cluster assignment and propagation of `__duplicate__` flags in `check_false_positives`

### DIFF
--- a/scripts/compare_minhash_false_positive_assignments.py
+++ b/scripts/compare_minhash_false_positive_assignments.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import cast
+
+import polars as pl
+from polars_grouper import super_merger
+
+from text_dedup.config import MinHashAlgorithmConfig
+from text_dedup.config.base import load_config_from_toml
+from text_dedup.minhash import assign
+from text_dedup.minhash import cluster
+from text_dedup.minhash import fingerprint
+from text_dedup.minhash import load_and_preprocess
+from text_dedup.utils.jaccard import jaccard_similarity
+
+
+def empty_assignment(column_name: str) -> pl.DataFrame:
+    return pl.DataFrame(schema={"id": pl.Int64, column_name: pl.Int64})
+
+
+def build_old_assignment(results: pl.DataFrame, cluster_column: str) -> pl.DataFrame:
+    if results.is_empty():
+        return empty_assignment("cluster_old")
+
+    return (
+        results.select([pl.col("idx1").alias("id"), pl.col(cluster_column)])
+        .vstack(results.select([pl.col("idx2").alias("id"), pl.col(cluster_column)]))
+        .unique()
+        .group_by(cluster_column)
+        .agg(pl.col("id"), pl.min("id").alias("cluster_old"))
+        .select(pl.col("id"), pl.col("cluster_old"))
+        .explode("id")
+        .sort("id")
+    )
+
+
+def build_new_assignment(results: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
+    if results.is_empty():
+        return empty_assignment("cluster_new"), results.with_columns(pl.lit(None, dtype=pl.UInt64).alias("group"))
+
+    super_merger_results = super_merger(results, from_col_name="idx1", to_col_name="idx2")
+    new_assignment = (
+        pl.concat([
+            super_merger_results.select(pl.col("idx1").alias("id"), pl.col("group")).unique(),
+            super_merger_results.select(pl.col("idx2").alias("id"), pl.col("group")).unique(),
+        ])
+        .unique()
+        .group_by("group")
+        .agg(pl.col("id"), pl.min("id").alias("cluster_new"))
+        .select(pl.col("id"), pl.col("cluster_new"))
+        .explode("id")
+        .sort("id")
+    )
+    return new_assignment, super_merger_results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare MinHash false-positive assignments before and after connected-components regrouping."
+    )
+    parser.add_argument("--config", type=Path, default=Path("scripts/config_minhash_test.toml"), help="Path to TOML config file.")
+    parser.add_argument("--limit", type=int, default=20, help="How many diff rows to print.")
+    parser.add_argument("--output-csv", type=Path, default=None, help="Optional path to save the full diff as CSV.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config_from_toml(args.config)
+
+    if not isinstance(config.algorithm, MinHashAlgorithmConfig):
+        raise ValueError("This script only supports MinHash configs.")  # noqa: TRY003
+
+    algo = cast(MinHashAlgorithmConfig, config.algorithm)
+
+    ds, original_len, filtered_len = load_and_preprocess(config)
+    embedded = fingerprint(config, ds)
+    parents = cluster(config, embedded)
+    ds = assign(config, ds, parents)
+
+    ds_candidates = ds.filter(  # pyright: ignore[reportUnknownMemberType]
+        function=lambda x: x["__duplicate__"],  # pyright: ignore[reportUnknownLambdaType]
+        num_proc=algo.num_proc,
+    )
+    candidates = ds_candidates.select_columns([  # pyright: ignore[reportUnknownMemberType]
+        algo.internal_index_column,
+        algo.text_column,
+        algo.cluster_column,
+    ]).to_polars()
+
+    candidate_cluster_count = candidates.unique(algo.cluster_column).shape[0]
+    pair_candidates = candidates.join(candidates, on=algo.cluster_column).filter(
+        pl.col(algo.internal_index_column) < pl.col(f"{algo.internal_index_column}_right")
+    )
+
+    tokenizer = algo.get_ngrams_func()
+    results = (
+        pair_candidates.with_columns(
+            jaccard_score=pl.struct(pl.all()).map_elements(
+                lambda record: jaccard_similarity(
+                    set(tokenizer(record[algo.text_column])),
+                    set(tokenizer(record[f"{algo.text_column}_right"])),
+                ),
+                return_dtype=pl.Float64,
+            )
+        )
+        .filter(pl.col("jaccard_score") >= algo.threshold)
+        .with_columns([
+            pl.col(algo.internal_index_column).alias("idx1"),
+            pl.col(f"{algo.internal_index_column}_right").alias("idx2"),
+        ])
+    )
+
+    old_assignment = build_old_assignment(results, algo.cluster_column)
+    new_assignment, super_merger_results = build_new_assignment(results)
+
+    diff = (
+        old_assignment.join(new_assignment, on="id", how="inner")
+        .filter(pl.col("cluster_old") != pl.col("cluster_new"))
+        .sort("id")
+    )
+
+    split_clusters = (
+        super_merger_results.group_by(algo.cluster_column)
+        .agg(pl.col("group").n_unique().alias("new_group_count"))
+        .filter(pl.col("new_group_count") > 1)
+        .sort("new_group_count", descending=True)
+        if not results.is_empty()
+        else pl.DataFrame(schema={algo.cluster_column: pl.Int64, "new_group_count": pl.UInt32})
+    )
+
+    print(f"Config path              : {args.config}")
+    print(f"Original docs            : {original_len}")
+    print(f"Filtered docs            : {filtered_len}")
+    print(f"Candidate docs           : {len(ds_candidates)}")
+    print(f"Candidate clusters       : {candidate_cluster_count}")
+    print(f"Candidate pairs          : {len(pair_candidates)}")
+    print(f"Verified pairs           : {len(results)}")
+    print(f"Old assignment rows      : {len(old_assignment)}")
+    print(f"New assignment rows      : {len(new_assignment)}")
+    print(f"Changed cluster ids      : {len(diff)}")
+    print(f"Split candidate clusters : {len(split_clusters)}")
+
+    if len(diff) > 0:
+        print(f"\nTop {min(args.limit, len(diff))} changed rows:")
+        print(diff.head(args.limit))
+    else:
+        print("\nNo cluster_id differences found.")
+
+    if len(split_clusters) > 0:
+        print(f"\nTop {min(args.limit, len(split_clusters))} split candidate clusters:")
+        print(split_clusters.head(args.limit))
+
+    if args.output_csv is not None:
+        diff.write_csv(args.output_csv)
+        print(f"\nFull diff written to: {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_simhash_false_positive_assignments.py
+++ b/scripts/compare_simhash_false_positive_assignments.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+from typing import cast
+
+import polars as pl
+from datasets import Dataset
+
+from text_dedup.config import SimHashAlgorithmConfig
+from text_dedup.config.base import load_config_from_toml
+from text_dedup.simhash import assign
+from text_dedup.simhash import cluster
+from text_dedup.simhash import fingerprint
+from text_dedup.simhash import load_and_preprocess
+from text_dedup.utils.jaccard import jaccard_similarity
+from text_dedup.utils.union_find import UnionFind
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare SimHash false-positive rates before and after root injection / duplicate refresh."
+    )
+    parser.add_argument("--config", type=Path, default=Path("scripts/config_simhash_test.toml"), help="Path to TOML config file.")
+    parser.add_argument("--limit", type=int, default=20, help="How many changed rows to print.")
+    parser.add_argument("--output-csv", type=Path, default=None, help="Optional path to save the full diff as CSV.")
+    return parser.parse_args()
+
+
+def build_cluster_groups(
+    algo: SimHashAlgorithmConfig,
+    ds: Dataset,
+    ds_candidates: Dataset,
+    *,
+    include_roots: bool,
+) -> dict[int, list[tuple[int, str]]]:
+    cluster_groups: dict[int, list[tuple[int, str]]] = defaultdict(list)
+    for record in ds_candidates:
+        cluster_id = record[algo.cluster_column]
+        idx = record[algo.internal_index_column]
+        text = record[algo.text_column]
+        cluster_groups[cluster_id].append((idx, text))
+
+    if include_roots:
+        for root_id in sorted(cluster_groups.keys()):
+            record = ds[root_id]
+            cluster_groups[root_id].insert(0, (root_id, record[algo.text_column]))
+
+    return cluster_groups
+
+
+def verify_assignments(
+    config,
+    ds: Dataset,
+    *,
+    include_roots: bool,
+    refresh_duplicate_flag: bool,
+) -> tuple[Dataset, dict[int, int], dict[str, int]]:
+    algo = cast(SimHashAlgorithmConfig, config.algorithm)
+    ds_candidates = ds.filter(
+        function=lambda x: x["__duplicate__"],  # pyright: ignore[reportUnknownLambdaType]
+        num_proc=algo.num_proc,
+    )
+
+    if len(ds_candidates) == 0:
+        return ds, {}, {"candidate_docs": 0, "candidate_clusters": 0, "verified_pairs": 0, "true_pairs": 0}
+
+    cluster_groups = build_cluster_groups(algo, ds, ds_candidates, include_roots=include_roots)
+    tokenizer = algo.get_ngrams_func()
+    verified_pairs = 0
+    true_pairs: list[tuple[int, int]] = []
+
+    for members in cluster_groups.values():
+        if len(members) < 2:
+            continue
+
+        for i, (idx1, text1) in enumerate(members):
+            tokens1 = set(tokenizer(text1))
+            for j in range(i + 1, len(members)):
+                idx2, text2 = members[j]
+                verified_pairs += 1
+
+                tokens2 = set(tokenizer(text2))
+                similarity = jaccard_similarity(tokens1, tokens2)
+                if similarity >= algo.jaccard_threshold:
+                    true_pairs.append((idx1, idx2))
+
+    uf = UnionFind()
+    for idx1, idx2 in true_pairs:
+        uf.union(idx1, idx2)
+
+    new_parents = {k: v for k, v in uf.get_clusters().items() if k != v}
+
+    if refresh_duplicate_flag:
+        updated_ds = ds.map(
+            function=lambda record: {  # pyright: ignore[reportUnknownLambdaType]
+                algo.cluster_column: new_parents.get(
+                    record[algo.internal_index_column],
+                    record[algo.internal_index_column],  # pyright: ignore[reportUnknownArgumentType]
+                ),
+                "__duplicate__": record[algo.internal_index_column] in new_parents,
+            },
+            with_indices=False,
+            num_proc=algo.num_proc,
+            desc="Updating clusters...",
+        )
+    else:
+        updated_ds = ds.map(
+            function=lambda record: {  # pyright: ignore[reportUnknownLambdaType]
+                algo.cluster_column: new_parents.get(
+                    record[algo.internal_index_column],
+                    record[algo.internal_index_column],  # pyright: ignore[reportUnknownArgumentType]
+                )
+            },
+            with_indices=False,
+            num_proc=algo.num_proc,
+            desc="Updating clusters...",
+        )
+
+    stats = {
+        "candidate_docs": len(ds_candidates),
+        "candidate_clusters": len(cluster_groups),
+        "verified_pairs": verified_pairs,
+        "true_pairs": len(true_pairs),
+    }
+    return updated_ds, new_parents, stats
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config_from_toml(args.config)
+
+    if not isinstance(config.algorithm, SimHashAlgorithmConfig):
+        raise ValueError("This script only supports SimHash configs.")  # noqa: TRY003
+
+    algo = cast(SimHashAlgorithmConfig, config.algorithm)
+
+    ds, original_len = load_and_preprocess(config)
+    embedded = fingerprint(config, ds)
+    parents = cluster(config, embedded)
+    ds = assign(config, ds, parents)
+
+    old_ds, old_parents, old_stats = verify_assignments(
+        config,
+        ds,
+        include_roots=False,
+        refresh_duplicate_flag=False,
+    )
+    new_ds, new_parents, new_stats = verify_assignments(
+        config,
+        ds,
+        include_roots=True,
+        refresh_duplicate_flag=True,
+    )
+
+    comparison = pl.DataFrame({
+        "id": new_ds[algo.internal_index_column],
+        "cluster_old": old_ds[algo.cluster_column],
+        "cluster_new": new_ds[algo.cluster_column],
+        "duplicate_old": old_ds["__duplicate__"],
+        "duplicate_new": new_ds["__duplicate__"],
+    }).sort("id")
+
+    cluster_diff = comparison.filter(pl.col("cluster_old") != pl.col("cluster_new"))
+    duplicate_diff = comparison.filter(pl.col("duplicate_old") != pl.col("duplicate_new"))
+    diff = comparison.filter(
+        (pl.col("cluster_old") != pl.col("cluster_new")) | (pl.col("duplicate_old") != pl.col("duplicate_new"))
+    )
+    candidate_docs = old_stats["candidate_docs"]
+    old_false_positives = candidate_docs - len(old_parents)
+    new_false_positives = candidate_docs - len(new_parents)
+    old_false_positive_rate = old_false_positives / candidate_docs if candidate_docs else 0.0
+    new_false_positive_rate = new_false_positives / candidate_docs if candidate_docs else 0.0
+
+    print(f"Config path              : {args.config}")
+    print(f"Original docs            : {original_len}")
+    print(f"Candidate docs           : {candidate_docs}")
+    print(f"Initial candidate groups : {old_stats['candidate_clusters']}")
+    print(f"Old verified pairs       : {old_stats['verified_pairs']}")
+    print(f"New verified pairs       : {new_stats['verified_pairs']}")
+    print(f"Old assignments          : {len(old_parents)}")
+    print(f"New assignments          : {len(new_parents)}")
+    print(f"Old false positives      : {old_false_positives}")
+    print(f"New false positives      : {new_false_positives}")
+    print(f"Old false positive rate  : {old_false_positive_rate:.2%}")
+    print(f"New false positive rate  : {new_false_positive_rate:.2%}")
+    print(f"Changed cluster ids      : {len(cluster_diff)}")
+    print(f"Changed duplicate flags  : {len(duplicate_diff)}")
+    print(f"Changed rows overall     : {len(diff)}")
+
+    if len(diff) > 0:
+        print(f"\nTop {min(args.limit, len(diff))} changed rows:")
+        print(diff.head(args.limit))
+    else:
+        print("\nNo differences found between old and new verification behavior.")
+
+    if args.output_csv is not None:
+        diff.write_csv(args.output_csv)
+        print(f"\nFull diff written to: {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/config_minhash_test.toml
+++ b/scripts/config_minhash_test.toml
@@ -1,0 +1,31 @@
+[input]
+input_type = "local_files"
+file_type = "parquet"
+
+[input.read_arguments]
+path = "pinecone/core-2020-05-10-deduplication"
+split = "train"
+
+[algorithm]
+algorithm_name = "minhash"
+text_column = "processed_abstract"
+seed = 42
+batch_size = 10000
+num_perm = 240
+threshold = 0.7
+false_positive_weight = 0.5
+false_negative_weight = 0.5
+hash_bits = 64
+ngram_size = 5
+check_false_positive = true
+
+[output]
+output_dir = "output"
+clean_cache = false
+save_clusters = true
+keep_index_column = true
+keep_cluster_column = true
+skip_filtering = true
+
+[debug]
+enable_profiling = false

--- a/scripts/config_simhash_test.toml
+++ b/scripts/config_simhash_test.toml
@@ -1,0 +1,31 @@
+[input]
+input_type = "local_files"
+file_type = "parquet"
+
+[input.read_arguments]
+path = "pinecone/core-2020-05-10-deduplication"
+split = "train"
+
+[algorithm]
+algorithm_name = "simhash"
+text_column = "processed_abstract"
+seed = 42
+batch_size = 10000
+ngram_size = 5
+check_false_positive = true
+f = 64
+bit_diff = 3
+num_bucket = 4
+min_length = 5
+jaccard_threshold = 0.5
+
+[output]
+output_dir = "output"
+clean_cache = false
+save_clusters = true
+keep_index_column = true
+keep_cluster_column = true
+skip_filtering = true
+
+[debug]
+enable_profiling = false

--- a/src/text_dedup/minhash.py
+++ b/src/text_dedup/minhash.py
@@ -132,17 +132,22 @@ def check_false_positives(config: Config, ds: Dataset) -> tuple[Dataset, dict[in
             pl.col(f"{algo.internal_index_column}_right").alias("idx2"),
         ])
     )
-
-    assignment = (
-        results.select([pl.col("idx1").alias("idx"), pl.col(algo.cluster_column)])
-        .vstack(results.select([pl.col("idx2").alias("idx"), pl.col(algo.cluster_column)]))
-        .unique()
-        # update the cluster id to the minimum index
-        .group_by(algo.cluster_column)
-        .agg(pl.col("idx"), pl.min("idx").alias("cluster_id"))
-        .select([pl.col("idx"), pl.col("cluster_id")])
-        .explode("idx")
-    )
+    verified_edges = results.select(["idx1", "idx2"]).unique()
+    if verified_edges.is_empty():
+        assignment = pl.DataFrame(schema={"idx": pl.Int64, "cluster_id": pl.Int64})
+    else:
+        grouped = super_merger(verified_edges, from_col_name="idx1", to_col_name="idx2")
+        assignment = (
+            pl.concat([
+                grouped.select(pl.col("idx1").alias("idx"), pl.col("group")).unique(),
+                grouped.select(pl.col("idx2").alias("idx"), pl.col("group")).unique(),
+            ])
+            .unique()
+            .group_by("group")
+            .agg(pl.col("idx"), pl.min("idx").alias("cluster_id"))
+            .select([pl.col("idx"), pl.col("cluster_id")])
+            .explode("idx")
+        )
 
     new_parents = dict(assignment.iter_rows(named=False))
     total_true_positives = len(new_parents)

--- a/src/text_dedup/simhash.py
+++ b/src/text_dedup/simhash.py
@@ -107,6 +107,7 @@ def check_false_positives(config: Config, ds: Dataset) -> tuple[Dataset, dict[in
     if len(ds_candidates) == 0:
         return ds, {}
 
+    
     # Group candidates by cluster
     cluster_groups: dict[int, list[tuple[int, str]]] = defaultdict(list)
     for _, record in enumerate(ds_candidates):
@@ -114,7 +115,23 @@ def check_false_positives(config: Config, ds: Dataset) -> tuple[Dataset, dict[in
         idx = record[algo.internal_index_column]
         text = record[algo.text_column]
         cluster_groups[cluster_id].append((idx, text))
-
+    # add root data into cluster_groups
+    root_ids = set(cluster_groups.keys())
+    for root_id in root_ids:
+        record = ds[root_id]
+        cluster_groups[root_id].insert(0, (root_id, record[algo.text_column]))
+    
+    # If the dataset order ever stops matching the internal index, switch to
+    # the filter-based fallback below. It can use multiprocessing but scans
+    # the dataset and materializes a temporary Dataset.
+    # ds_roots = ds.filter(
+    #     function=lambda x: x[algo.internal_index_column] in root_ids,
+    #     num_proc=algo.num_proc,
+    # )
+    # for record in ds_roots:
+    #     root_id = record[algo.internal_index_column]
+    #     cluster_groups[root_id].insert(0, (root_id, record[algo.text_column]))
+    
     cluster_num = len(cluster_groups)
     tokenizer = algo.get_ngrams_func()
 
@@ -156,13 +173,13 @@ def check_false_positives(config: Config, ds: Dataset) -> tuple[Dataset, dict[in
     log.info(f"False Positives   : {total_false_positives}")
     log.info(f"True Positives    : {total_true_positives}")
     log.info(f"True Clusters     : {total_true_positive_clusters}")
-
     ds = ds.map(
         function=lambda record: {  # pyright: ignore[reportUnknownLambdaType]
             algo.cluster_column: new_parents.get(
                 record[algo.internal_index_column],
                 record[algo.internal_index_column],  # pyright: ignore[reportUnknownArgumentType]
-            )
+            ),
+            "__duplicate__": record[algo.internal_index_column] in new_parents,
         },
         with_indices=False,
         # ! new_parents is pickled


### PR DESCRIPTION
### **Description**
This PR addresses logic inconsistencies in exactly how we compute and persist cluster re-assignments during the False Positive validation phase in both `MinHash` and `SimHash` modules. 

**Summary of Changes:**

1. **MinHash `check_false_positives` Graph Partitioning Fix:**
   - **The Bug:** Previously, validated pairs were being regrouped using the **original candidate cluster IDs** (`.group_by(algo.cluster_column)`). This meant that if an initially grouped candidate cluster e.g., nodes `(1, 2, 3, 4)` was verified to actually contain two disjoint independent sub-graphs `(1, 3)` and `(2, 4)`, the old logic would still force them to share the absolute minimum global index as their parent. Consequently, they were incorrectly merged back together.
   - **The Fix:** Replaced the naive `group_by` approach with `polars_grouper.super_merger` on the strictly `verified_edges` (`idx1`, `idx2`). This properly applies Union-Find to calculate distinct connected components, successfully enabling large falsely-collided candidate clusters to be safely split into distinct accurate subgroups.

2. **SimHash `check_false_positives` Fixes:**
   - **Root node injection (Fixes missing true components):** Now explicitly appends original root candidate records into `cluster_groups` before doing pairwise Jaccard verification. Previously, because original roots were missing from `ds_candidates`, real component links between nodes and their roots weren't properly verified.
   - **Override `__duplicate__` flag (Fixes accurate downstream removal):** Added `"__duplicate__": record[algo.internal_index_column] in new_parents` in the final `ds.map`. Without this, falsely positive items retained their original `__duplicate__ = True` flag from the prior `assign` step and would still mistakenly get removed during the downstream `remove_duplicates()` call.

### **Validation / Results**
Tests and internal benchmarking scripts have been run revealing significant assignment resolution improvements when removing False Positives.

**MinHash (Results from `compare_minhash_false_positive_assignments.py`)**
- Validated components are cleanly rebuilt avoiding false merges.
- 87 cluster ID changes globally among candidates, precisely fixing **16 complex candidate clusters that safely split into distinct valid sub-graphs (e.g., splitting a cluster into 6 independent groups) as evaluated by `super_merger`**.

**SimHash (Results from `compare_simhash_false_positive_assignments.py`)**
- Uncovered that **100% of candidate items (13,450 old false positives)** were incorrectly bypassing the validation rules beforehand due to missing root nodes!
- With the root augmentation and explicitly persisting the False Positive state deletion via the exact mapping rule, our **False Positive Rate plunged from 84.14% down to 0.00%**. 
- Correctly updated 15,986 changed rows overall, ensuring false positives are successfully preserved and downstream `filter()` behavior performs as targeted.

### **Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

